### PR TITLE
fix: resolve benchmark README push conflicts with pull-rebase retry

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -169,6 +169,34 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
           # Only commit if the file actually changed
-          git diff --cached --quiet \
-            || git commit -m "chore: update benchmark results in README [skip ci]"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "chore: update benchmark results in README [skip ci]"
+
+          # Pull-rebase to handle concurrent pushes (e.g., publish workflow's
+          # auto-version-bump commit that landed while benchmarks were running).
+          # Retry up to 3 times in case of transient conflicts.
+          for attempt in 1 2 3; do
+            echo "Push attempt ${attempt}..."
+            if git push; then
+              echo "✅ Pushed successfully on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Push failed — pulling latest changes and retrying..."
+            git pull --rebase origin main
+
+            # Re-run the README update script on the rebased tree so the
+            # content stays correct after incorporating upstream changes.
+            python3 scripts/update-readme-benchmarks.py \
+              src/EggMapper.Benchmarks/BenchmarkDotNet.Artifacts \
+              README.md
+            git add README.md
+            if ! git diff --cached --quiet; then
+              git commit --amend --no-edit
+            fi
+          done
+
+          echo "❌ Failed to push after 3 attempts."
+          exit 1


### PR DESCRIPTION
## Summary

The benchmark workflow fails when the publish workflow commits a version bump to main while benchmarks are running. The push is rejected because the local checkout is stale.

## Fix

Added `git pull --rebase` before push with 3 retry attempts. On each retry:
1. Pulls latest changes from main with rebase
2. Re-runs the README update script on the rebased tree
3. Amends the commit and retries the push

This handles the race condition between the benchmark and publish workflows that both commit to main.

## Root cause
```
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)