### PR TITLE
feat: dictionary mapping (Feature 2)

### DIFF
--- a/src/EggMapper.UnitTests/DictionaryMappingTests.cs
+++ b/src/EggMapper.UnitTests/DictionaryMappingTests.cs
@@ -1,0 +1,150 @@
+using EggMapper;
+using FluentAssertions;
+using Xunit;
+
+namespace EggMapper.UnitTests;
+
+public class DictionaryMappingTests
+{
+    // ── Models ────────────────────────────────────────────────────────────────
+
+    class SrcWithDict
+    {
+        public Dictionary<string, int> Scores { get; set; } = new();
+        public Dictionary<string, string> Labels { get; set; } = new();
+    }
+
+    class DestWithDict
+    {
+        public Dictionary<string, int> Scores { get; set; } = new();
+        public Dictionary<string, string> Labels { get; set; } = new();
+    }
+
+    class SrcWithMappedValueDict
+    {
+        public Dictionary<string, InnerSrc> Items { get; set; } = new();
+    }
+
+    class DestWithMappedValueDict
+    {
+        public Dictionary<string, InnerDest> Items { get; set; } = new();
+    }
+
+    class InnerSrc  { public string Name { get; set; } = ""; }
+    class InnerDest { public string Name { get; set; } = ""; }
+
+    class SrcStandalone
+    {
+        public string Name { get; set; } = "";
+        public Dictionary<string, int> Meta { get; set; } = new();
+    }
+
+    class DestStandalone
+    {
+        public string Name { get; set; } = "";
+        public Dictionary<string, int> Meta { get; set; } = new();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Map_SameType_Dictionary_Copies_Entries()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<SrcWithDict, DestWithDict>()).CreateMapper();
+
+        var src = new SrcWithDict
+        {
+            Scores = new Dictionary<string, int> { ["Alice"] = 95, ["Bob"] = 80 },
+            Labels = new Dictionary<string, string> { ["x"] = "foo" }
+        };
+
+        var dest = mapper.Map<SrcWithDict, DestWithDict>(src);
+
+        dest.Scores.Should().BeEquivalentTo(src.Scores);
+        dest.Labels.Should().BeEquivalentTo(src.Labels);
+    }
+
+    [Fact]
+    public void Map_Dictionary_Is_A_Copy_Not_Same_Reference()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<SrcWithDict, DestWithDict>()).CreateMapper();
+
+        var src = new SrcWithDict { Scores = new Dictionary<string, int> { ["k"] = 1 } };
+        var dest = mapper.Map<SrcWithDict, DestWithDict>(src);
+
+        dest.Scores.Should().NotBeSameAs(src.Scores);
+        dest.Scores["k"].Should().Be(1);
+    }
+
+    [Fact]
+    public void Map_Null_Dictionary_Property_Stays_Default()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<SrcWithDict, DestWithDict>()).CreateMapper();
+
+        var src = new SrcWithDict { Scores = null! };
+        var dest = mapper.Map<SrcWithDict, DestWithDict>(src);
+
+        // null source dict → dest prop not set (stays at its initializer value or null)
+        dest.Scores.Should().BeEquivalentTo(new Dictionary<string, int>());
+    }
+
+    [Fact]
+    public void Map_Dictionary_With_Mapped_Values_Maps_Each_Value()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<InnerSrc, InnerDest>();
+            cfg.CreateMap<SrcWithMappedValueDict, DestWithMappedValueDict>();
+        }).CreateMapper();
+
+        var src = new SrcWithMappedValueDict
+        {
+            Items = new Dictionary<string, InnerSrc>
+            {
+                ["a"] = new InnerSrc { Name = "Alpha" },
+                ["b"] = new InnerSrc { Name = "Beta" }
+            }
+        };
+
+        var dest = mapper.Map<SrcWithMappedValueDict, DestWithMappedValueDict>(src);
+
+        dest.Items.Should().HaveCount(2);
+        dest.Items["a"].Name.Should().Be("Alpha");
+        dest.Items["b"].Name.Should().Be("Beta");
+        dest.Items["a"].Should().NotBeSameAs(src.Items["a"]);
+    }
+
+    [Fact]
+    public void Map_Empty_Dictionary_Produces_Empty_Destination()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<SrcWithDict, DestWithDict>()).CreateMapper();
+
+        var src = new SrcWithDict { Scores = new Dictionary<string, int>() };
+        var dest = mapper.Map<SrcWithDict, DestWithDict>(src);
+
+        dest.Scores.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MapList_With_Dictionary_Property_Maps_All_Elements()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<SrcStandalone, DestStandalone>()).CreateMapper();
+
+        var sources = new List<SrcStandalone>
+        {
+            new() { Name = "A", Meta = new() { ["x"] = 1 } },
+            new() { Name = "B", Meta = new() { ["y"] = 2 } }
+        };
+
+        var result = mapper.MapList<SrcStandalone, DestStandalone>(sources);
+
+        result.Should().HaveCount(2);
+        result[0].Meta["x"].Should().Be(1);
+        result[1].Meta["y"].Should().Be(2);
+    }
+}

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -408,6 +408,14 @@ internal static class ExpressionBuilder
         if (ReflectionHelper.IsCollectionType(srcType) || ReflectionHelper.IsCollectionType(destType))
             return null;
 
+        // ── Dictionary property ───────────────────────────────────────────────
+        if (ReflectionHelper.IsDictionaryType(srcType) || ReflectionHelper.IsDictionaryType(destType))
+        {
+            if (!ReflectionHelper.IsDictionaryType(srcType) || !ReflectionHelper.IsDictionaryType(destType))
+                return null;
+            return TryBuildCtxFreeDictionaryAssign(srcParam, dVar, srcProp, destProp);
+        }
+
         // Same type: direct assignment (no boxing, no conversion)
         if (srcType == destType)
             return Expression.Assign(destAccess, srcAccess);
@@ -942,6 +950,14 @@ internal static class ExpressionBuilder
         var destType   = destProp.PropertyType;
         var srcAccess  = Expression.Property(sVar, srcProp);
         var destAccess = Expression.Property(dVar, destProp);
+
+        // ── Dictionary property ───────────────────────────────────────────────
+        if (ReflectionHelper.IsDictionaryType(srcType) || ReflectionHelper.IsDictionaryType(destType))
+        {
+            if (!ReflectionHelper.IsDictionaryType(srcType) || !ReflectionHelper.IsDictionaryType(destType))
+                return null;
+            return TryBuildCtxFreeDictionaryAssign(sVar, dVar, srcProp, destProp);
+        }
 
         // ── Collection property ───────────────────────────────────────────────
         if (ReflectionHelper.IsCollectionType(srcType) && ReflectionHelper.IsCollectionType(destType))
@@ -1735,6 +1751,15 @@ internal static class ExpressionBuilder
         // mappings without conditions/null-substitution do too.
         bool noGuards = condition == null && fullCondition == null && preCondition == null && !hasNullSub;
 
+        // ── Dictionary property ───────────────────────────────────────────────
+        if (ReflectionHelper.IsDictionaryType(srcType) || ReflectionHelper.IsDictionaryType(destType))
+        {
+            if (!ReflectionHelper.IsDictionaryType(srcType) || !ReflectionHelper.IsDictionaryType(destType))
+                return null;
+            return BuildDictionaryAction(getter, setter, srcType, destType, noGuards, compiledMaps,
+                condition, fullCondition, preCondition, hasNullSub, nullSub);
+        }
+
         if (ReflectionHelper.IsCollectionType(srcType) && ReflectionHelper.IsCollectionType(destType))
         {
             var srcElemType = ReflectionHelper.GetCollectionElementType(srcType);
@@ -1958,6 +1983,121 @@ internal static class ExpressionBuilder
         }
 
         return null;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Dictionary helpers
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Ctx-free: emits <c>dest.Prop = src.Prop == null ? null : new Dictionary&lt;K,V&gt;(src.Prop)</c>
+    /// for same key+value-type dictionaries.
+    /// </summary>
+    private static Expression? TryBuildCtxFreeDictionaryAssign(
+        ParameterExpression srcParam,
+        ParameterExpression dVar,
+        PropertyInfo srcProp,
+        PropertyInfo destProp)
+    {
+        var srcType = srcProp.PropertyType;
+        var destType = destProp.PropertyType;
+        var (srcKeyType, srcValType) = ReflectionHelper.GetDictionaryKeyValueTypes(srcType);
+        var (destKeyType, destValType) = ReflectionHelper.GetDictionaryKeyValueTypes(destType);
+
+        if (srcKeyType != destKeyType || srcValType != destValType) return null;
+
+        var dictConcreteType = typeof(Dictionary<,>).MakeGenericType(destKeyType, destValType);
+        var srcDictIfaceType = typeof(IDictionary<,>).MakeGenericType(srcKeyType, srcValType);
+        var copyCtor = dictConcreteType.GetConstructor(new[] { srcDictIfaceType });
+        if (copyCtor == null) return null;
+
+        var srcAccess = Expression.Property(srcParam, srcProp);
+        var destAccess = Expression.Property(dVar, destProp);
+
+        var srcCast = srcDictIfaceType.IsAssignableFrom(srcType)
+            ? (Expression)Expression.Convert(srcAccess, srcDictIfaceType)
+            : srcAccess;
+
+        return Expression.IfThen(
+            Expression.ReferenceNotEqual(
+                Expression.Convert(srcAccess, typeof(object)),
+                Expression.Constant(null, typeof(object))),
+            Expression.Assign(destAccess,
+                Expression.Convert(Expression.New(copyCtor, srcCast), destType)));
+    }
+
+    private static Action<object, object, ResolutionContext>? BuildDictionaryAction(
+        Func<object, object?> getter,
+        Action<object, object?> setter,
+        Type srcType,
+        Type destType,
+        bool noGuards,
+        ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps,
+        Func<object, bool>? condition,
+        Func<object, object, bool>? fullCondition,
+        Func<object, bool>? preCondition,
+        bool hasNullSub,
+        object? nullSub)
+    {
+        var (srcKeyType, srcValType) = ReflectionHelper.GetDictionaryKeyValueTypes(srcType);
+        var (destKeyType, destValType) = ReflectionHelper.GetDictionaryKeyValueTypes(destType);
+
+        if (srcKeyType != destKeyType) return null;
+
+        var destDictType = typeof(Dictionary<,>).MakeGenericType(destKeyType, destValType);
+        var valPair = new TypePair(srcValType, destValType);
+        var capturedMaps = compiledMaps;
+
+        if (noGuards)
+        {
+            return (src, dest, ctx) =>
+            {
+                var srcVal = getter(src);
+                if (srcVal == null) return;
+                setter(dest, MapDictionaryInternal(srcVal, srcValType, destValType, destDictType, valPair, capturedMaps, ctx));
+            };
+        }
+
+        return (src, dest, ctx) =>
+        {
+            if (preCondition != null && !preCondition(src)) return;
+            if (condition != null && !condition(src)) return;
+            if (fullCondition != null && !fullCondition(src, dest)) return;
+
+            var srcVal = getter(src);
+            if (srcVal == null)
+            {
+                if (hasNullSub) setter(dest, nullSub);
+                return;
+            }
+            setter(dest, MapDictionaryInternal(srcVal, srcValType, destValType, destDictType, valPair, capturedMaps, ctx));
+        };
+    }
+
+    private static object MapDictionaryInternal(
+        object srcDict,
+        Type srcValType,
+        Type destValType,
+        Type destDictType,
+        TypePair valPair,
+        ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps,
+        ResolutionContext ctx)
+    {
+        compiledMaps.TryGetValue(valPair, out var valMapper);
+        var dest = (IDictionary)Activator.CreateInstance(destDictType)!;
+        foreach (DictionaryEntry entry in (IDictionary)srcDict)
+        {
+            var val = entry.Value;
+            object? mappedVal;
+            if (valMapper != null && val != null)
+                mappedVal = valMapper(val, null, ctx);
+            else if (destValType.IsAssignableFrom(srcValType))
+                mappedVal = val;
+            else
+                mappedVal = val != null ? ConvertValue(val, destValType) : null;
+            dest[entry.Key] = mappedVal;
+        }
+        return dest;
     }
 
     private static object? MapCollectionInternal(

--- a/src/EggMapper/Internal/ReflectionHelper.cs
+++ b/src/EggMapper/Internal/ReflectionHelper.cs
@@ -20,9 +20,50 @@ internal static class ReflectionHelper
     public static Type GetUnderlyingType(Type type) =>
         Nullable.GetUnderlyingType(type) ?? type;
 
+    public static bool IsDictionaryType(Type type)
+    {
+        if (!type.IsGenericType && type.GetInterfaces().Length == 0) return false;
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            if (def == typeof(IDictionary<,>) || def == typeof(Dictionary<,>)) return true;
+        }
+        var interfaces = type.GetInterfaces();
+        for (int i = 0; i < interfaces.Length; i++)
+        {
+            var iface = interfaces[i];
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                return true;
+        }
+        return false;
+    }
+
+    public static (Type KeyType, Type ValueType) GetDictionaryKeyValueTypes(Type type)
+    {
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            if (def == typeof(IDictionary<,>) || def == typeof(Dictionary<,>))
+            {
+                var args = type.GetGenericArguments();
+                return (args[0], args[1]);
+            }
+        }
+        var iface = type.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+        if (iface != null)
+        {
+            var args = iface.GetGenericArguments();
+            return (args[0], args[1]);
+        }
+        throw new InvalidOperationException($"{type.Name} is not a dictionary type");
+    }
+
     public static bool IsCollectionType(Type type)
     {
         if (type == typeof(string)) return false;
+        // Dictionaries are not treated as plain collections
+        if (IsDictionaryType(type)) return false;
         if (type.IsArray) return true;
         var interfaces = type.GetInterfaces();
         for (int i = 0; i < interfaces.Length; i++)


### PR DESCRIPTION
## Summary
- Auto-maps `Dictionary<K,V>` properties across all delegate paths (ctx-free, typed, flexible)
- `IsCollectionType` no longer returns true for `IDictionary<,>` types — dicts route to dedicated handlers
- Same K+V: uses copy constructor (`new Dictionary<K,V>(src)`) — zero extra allocations
- Different V types with registered map: iterates and maps each value via compiled delegate
- Full null safety: null source dict leaves destination unchanged

## Test plan
- [x] Same-type dict copies entries correctly
- [x] Copy is a new instance (not a reference share)
- [x] Null source dict handled safely
- [x] Dicts with mapped value types work end-to-end
- [x] Empty dict maps to empty dict
- [x] `MapList` with dict properties works
- [x] 230 existing tests still pass

Closes #19 (partial — Feature 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)