### PR TITLE
feat: global DefaultMaxDepth safety net (Feature 3)

### DIFF
--- a/src/EggMapper.UnitTests/DefaultMaxDepthTests.cs
+++ b/src/EggMapper.UnitTests/DefaultMaxDepthTests.cs
@@ -1,0 +1,124 @@
+using EggMapper;
+using EggMapper.UnitTests.TestModels;
+using FluentAssertions;
+using Xunit;
+
+namespace EggMapper.UnitTests;
+
+/// <summary>
+/// Tests for the global DefaultMaxDepth safety net (Feature 3).
+/// DefaultMaxDepth only applies to the flexible delegate path (maps with hooks,
+/// conditions, inheritance, etc.) — not to the ctx-free or typed paths.
+/// Individual per-map MaxDepth is covered by MaxDepthTests.cs.
+/// </summary>
+public class DefaultMaxDepthTests
+{
+    private static NodeSrc BuildChain(int levels)
+    {
+        var root = new NodeSrc { Name = "L0" };
+        var current = root;
+        for (int i = 1; i < levels; i++)
+        {
+            var next = new NodeSrc { Name = $"L{i}" };
+            current.Child = next;
+            current = next;
+        }
+        return root;
+    }
+
+    [Fact]
+    public void DefaultMaxDepth_32_is_default()
+    {
+        // Verify the default DefaultMaxDepth value is 32
+        int captured = 0;
+        _ = new MapperConfiguration(cfg =>
+        {
+            captured = cfg.DefaultMaxDepth;
+            cfg.CreateMap<NodeSrc, NodeDst>();
+        });
+        captured.Should().Be(32);
+    }
+
+    [Fact]
+    public void DefaultMaxDepth_applies_to_flexible_path_maps()
+    {
+        // Maps with hooks use the flexible delegate path — DefaultMaxDepth applies there.
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.DefaultMaxDepth = 2;
+            cfg.CreateMap<NodeSrc, NodeDst>()
+               .BeforeMap((src, dest) => { }); // Forces flexible delegate path
+        }).CreateMapper();
+
+        var src = BuildChain(5); // L0 → L1 → L2 → L3 → L4
+        var dest = mapper.Map<NodeSrc, NodeDst>(src);
+
+        dest.Name.Should().Be("L0");
+        dest.Child.Should().NotBeNull();
+        dest.Child!.Name.Should().Be("L1");
+        dest.Child.Child.Should().BeNull(); // DefaultMaxDepth=2 cuts at depth 2
+    }
+
+    [Fact]
+    public void DefaultMaxDepth_1_stops_at_root_in_flexible_path()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.DefaultMaxDepth = 1;
+            cfg.CreateMap<NodeSrc, NodeDst>()
+               .BeforeMap((src, dest) => { });
+        }).CreateMapper();
+
+        var src = BuildChain(3);
+        var dest = mapper.Map<NodeSrc, NodeDst>(src);
+
+        dest.Name.Should().Be("L0");
+        dest.Child.Should().BeNull();
+    }
+
+    [Fact]
+    public void DefaultMaxDepth_0_disables_safety_net()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.DefaultMaxDepth = 0;
+            cfg.CreateMap<NodeSrc, NodeDst>()
+               .BeforeMap((src, dest) => { });
+        }).CreateMapper();
+
+        var src = BuildChain(5);
+        var dest = mapper.Map<NodeSrc, NodeDst>(src);
+
+        // All 5 levels mapped when safety net is disabled
+        dest.Child!.Child!.Child!.Child!.Name.Should().Be("L4");
+    }
+
+    [Fact]
+    public void PerMap_MaxDepth_overrides_DefaultMaxDepth()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.DefaultMaxDepth = 10;
+            cfg.CreateMap<NodeSrc, NodeDst>().MaxDepth(2); // per-map MaxDepth wins
+        }).CreateMapper();
+
+        var src = BuildChain(5);
+        var dest = mapper.Map<NodeSrc, NodeDst>(src);
+
+        dest.Child.Should().NotBeNull();
+        dest.Child!.Child.Should().BeNull(); // MaxDepth(2) cuts at depth 2
+    }
+
+    [Fact]
+    public void DefaultMaxDepth_is_configurable()
+    {
+        int captured = 0;
+        _ = new MapperConfiguration(cfg =>
+        {
+            cfg.DefaultMaxDepth = 64;
+            captured = cfg.DefaultMaxDepth;
+            cfg.CreateMap<NodeSrc, NodeDst>();
+        });
+        captured.Should().Be(64);
+    }
+}

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -71,7 +71,8 @@ internal static class ExpressionBuilder
     public static Func<object, object?, ResolutionContext, object> BuildMappingDelegate(
         TypeMap typeMap,
         Dictionary<TypePair, TypeMap> allTypeMaps,
-        ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps)
+        ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps,
+        int defaultMaxDepth = 32)
     {
         // Fast path: compile a single typed Expression tree (no per-property delegate
         // calls, no boxing of value types in the hot loop).  Falls back to the
@@ -80,7 +81,7 @@ internal static class ExpressionBuilder
         if (TryBuildTypedDelegate(typeMap, allTypeMaps, compiledMaps, out var fastDel))
             return fastDel!;
 
-        return BuildFlexibleDelegate(typeMap, allTypeMaps, compiledMaps);
+        return BuildFlexibleDelegate(typeMap, allTypeMaps, compiledMaps, defaultMaxDepth);
     }
 
     /// <summary>
@@ -1517,7 +1518,8 @@ internal static class ExpressionBuilder
     private static Func<object, object?, ResolutionContext, object> BuildFlexibleDelegate(
         TypeMap typeMap,
         Dictionary<TypePair, TypeMap> allTypeMaps,
-        ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps)
+        ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps,
+        int defaultMaxDepth = 32)
     {
         var factory = BuildFactory(typeMap);
         var srcDetails = TypeDetails.Get(typeMap.SourceType);
@@ -1569,7 +1571,8 @@ internal static class ExpressionBuilder
         var afterMap = typeMap.AfterMapAction;
         var beforeMapCtx = typeMap.BeforeMapCtxAction;
         var afterMapCtx = typeMap.AfterMapCtxAction;
-        var maxDepth = typeMap.MaxDepth;
+        // Per-map MaxDepth takes precedence; fall back to global default as safety net.
+        var maxDepth = typeMap.MaxDepth > 0 ? typeMap.MaxDepth : defaultMaxDepth;
 
         return (object src, object? dest, ResolutionContext ctx) =>
         {

--- a/src/EggMapper/IMapperConfigurationExpression.cs
+++ b/src/EggMapper/IMapperConfigurationExpression.cs
@@ -24,4 +24,11 @@ public interface IMapperConfigurationExpression
     /// Compatible with AutoMapper's ShouldMapProperty.
     /// </summary>
     Func<PropertyInfo, bool>? ShouldMapProperty { get; set; }
+
+    /// <summary>
+    /// Global maximum recursion depth applied as a safety net in the flexible delegate path.
+    /// Default is 32. Set to 0 to disable. Individual maps can override with .MaxDepth(n).
+    /// Prevents stack exhaustion from deeply or infinitely nested object graphs (CVE-class issue).
+    /// </summary>
+    int DefaultMaxDepth { get; set; }
 }

--- a/src/EggMapper/MapperConfiguration.cs
+++ b/src/EggMapper/MapperConfiguration.cs
@@ -24,11 +24,14 @@ public sealed class MapperConfiguration
 
     internal Func<System.Reflection.PropertyInfo, bool>? ShouldMapProperty { get; private set; }
 
+    internal int DefaultMaxDepth { get; private set; }
+
     public MapperConfiguration(Action<IMapperConfigurationExpression> configure)
     {
         var expr = new MapperConfigurationExpression();
         configure(expr);
         ShouldMapProperty = expr.GetShouldMapProperty();
+        DefaultMaxDepth = expr.GetDefaultMaxDepth();
 
         foreach (var typeMap in expr.GetTypeMaps())
         {
@@ -47,7 +50,7 @@ public sealed class MapperConfiguration
         var ctxFreeList = new Dictionary<TypePair, Delegate>();
 
         foreach (var typeMap in TopologicalOrder(_typeMaps))
-            CompileMap(typeMap, ctxFree, ctxFreeList);
+            CompileMap(typeMap, ctxFree, ctxFreeList, DefaultMaxDepth);
 
         // Snapshot: no further writes will occur after construction.
         FrozenMaps = new Dictionary<TypePair, Func<object, object?, ResolutionContext, object>>(_compiledMaps);
@@ -87,7 +90,8 @@ public sealed class MapperConfiguration
     private void CompileMap(
         TypeMap typeMap,
         Dictionary<TypePair, Delegate> ctxFree,
-        Dictionary<TypePair, Delegate> ctxFreeList)
+        Dictionary<TypePair, Delegate> ctxFreeList,
+        int defaultMaxDepth)
     {
         var key = new TypePair(typeMap.SourceType, typeMap.DestinationType);
         if (_compiledMaps.ContainsKey(key)) return;
@@ -119,7 +123,7 @@ public sealed class MapperConfiguration
         else
         {
             // Complex map (hooks, conditions, inheritance…) — fall back to full compilation.
-            var compiledDelegate = Execution.ExpressionBuilder.BuildMappingDelegate(typeMap, _typeMaps, _compiledMaps);
+            var compiledDelegate = Execution.ExpressionBuilder.BuildMappingDelegate(typeMap, _typeMaps, _compiledMaps, defaultMaxDepth);
             _compiledMaps[key] = compiledDelegate;
             typeMap.MappingDelegate = compiledDelegate;
         }

--- a/src/EggMapper/MapperConfigurationExpression.cs
+++ b/src/EggMapper/MapperConfigurationExpression.cs
@@ -69,9 +69,11 @@ internal sealed class MapperConfigurationExpression : IMapperConfigurationExpres
         AddProfiles(markerTypes.Select(t => t.Assembly).Distinct());
 
     public Func<PropertyInfo, bool>? ShouldMapProperty { get; set; }
+    public int DefaultMaxDepth { get; set; } = 32;
 
     internal IEnumerable<TypeMap> GetTypeMaps() => _typeMaps.Values;
     internal Func<PropertyInfo, bool>? GetShouldMapProperty() => ShouldMapProperty;
+    internal int GetDefaultMaxDepth() => DefaultMaxDepth;
 }
 
 internal sealed class MappingExpression<TSource, TDestination> : IMappingExpression<TSource, TDestination>


### PR DESCRIPTION
## Summary
- Adds `DefaultMaxDepth` property (default=32) to `IMapperConfigurationExpression`
- Applied as a safety net in `BuildFlexibleDelegate` — mirrors the AutoMapper CVE fix for DoS via uncontrolled recursion
- Per-map `.MaxDepth(n)` takes precedence over the global default
- Set `DefaultMaxDepth = 0` to disable the safety net entirely
- Zero performance impact on simple maps that use ctx-free or typed delegate paths

## Test plan
- [x] Default value is 32
- [x] DefaultMaxDepth limits recursion in flexible-path maps
- [x] DefaultMaxDepth=1 stops at root
- [x] DefaultMaxDepth=0 disables the safety net
- [x] Per-map MaxDepth overrides DefaultMaxDepth
- [x] 230 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)