### PR TITLE
feat: expression diagnostics/dump API (Feature 4)

### DIFF
--- a/src/EggMapper.UnitTests/ExpressionDiagnosticsTests.cs
+++ b/src/EggMapper.UnitTests/ExpressionDiagnosticsTests.cs
@@ -1,0 +1,69 @@
+using EggMapper;
+using EggMapper.UnitTests.TestModels;
+using FluentAssertions;
+using Xunit;
+
+namespace EggMapper.UnitTests;
+
+public class ExpressionDiagnosticsTests
+{
+    [Fact]
+    public void GetMappingExpressionText_returns_non_empty_string_for_simple_map()
+    {
+        var config = new MapperConfiguration(cfg =>
+            cfg.CreateMap<FlatSource, FlatDest>());
+
+        var text = config.GetMappingExpressionText<FlatSource, FlatDest>();
+
+        text.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void GetMappingExpressionText_contains_src_parameter()
+    {
+        var config = new MapperConfiguration(cfg =>
+            cfg.CreateMap<FlatSource, FlatDest>());
+
+        var text = config.GetMappingExpressionText<FlatSource, FlatDest>();
+
+        text.Should().Contain("src");
+        text.Should().Contain("=>");
+    }
+
+    [Fact]
+    public void GetMappingExpressionText_returns_null_for_unregistered_map()
+    {
+        var config = new MapperConfiguration(cfg =>
+            cfg.CreateMap<FlatSource, FlatDest>());
+
+        var text = config.GetMappingExpressionText<PersonSourceSimple, FlatDest>();
+
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetMappingExpressionText_is_a_lambda_expression_string()
+    {
+        var config = new MapperConfiguration(cfg =>
+            cfg.CreateMap<FlatSource, FlatDest>());
+
+        var text = config.GetMappingExpressionText<FlatSource, FlatDest>();
+
+        // Expression.ToString() produces a lambda-style representation
+        text.Should().StartWith("(");
+        text.Should().Contain("=>");
+    }
+
+    [Fact]
+    public void GetMappingExpressionText_works_for_nested_maps()
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<AddressSource, AddressDest>();
+            cfg.CreateMap<PersonSource, PersonDest>();
+        });
+
+        var text = config.GetMappingExpressionText<PersonSource, PersonDest>();
+        text.Should().NotBeNullOrEmpty();
+    }
+}

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -232,7 +232,9 @@ internal static class ExpressionBuilder
         var body     = Expression.Block(new[] { dVar }, stmts);
         // Func<TSrc, TDest, TDest> — second param is optional existing destination
         var funcType = typeof(Func<,,>).MakeGenericType(srcType, destType, destType);
-        return Expression.Lambda(funcType, body, srcParam, destParam).Compile();
+        var lambda = Expression.Lambda(funcType, body, srcParam, destParam);
+        typeMap.MappingExpression = lambda;
+        return lambda.Compile();
     }
 
     /// <summary>
@@ -918,6 +920,7 @@ internal static class ExpressionBuilder
         var body   = Expression.Block(new[] { sVar, dVar }, stmts);
         var lambda = Expression.Lambda<Func<object, object?, ResolutionContext, object>>(
             body, srcParam, destParam, ctxParam);
+        typeMap.MappingExpression = lambda;
 
         result = lambda.Compile();
         return true;

--- a/src/EggMapper/MapperConfiguration.cs
+++ b/src/EggMapper/MapperConfiguration.cs
@@ -167,6 +167,20 @@ public sealed class MapperConfiguration
 
     internal Dictionary<TypePair, TypeMap> TypeMaps => _typeMaps;
 
+    /// <summary>
+    /// Returns a human-readable string representation of the compiled expression tree
+    /// for the <typeparamref name="TSource"/> → <typeparamref name="TDestination"/> map.
+    /// Returns null when no expression tree is available (e.g. flexible delegate path or
+    /// ConvertUsing maps).
+    /// </summary>
+    public string? GetMappingExpressionText<TSource, TDestination>()
+    {
+        var key = new TypePair(typeof(TSource), typeof(TDestination));
+        if (!_typeMaps.TryGetValue(key, out var typeMap))
+            return null;
+        return typeMap.MappingExpression?.ToString();
+    }
+
     public void AssertConfigurationIsValid()
     {
         var errors = new List<string>();

--- a/src/EggMapper/TypeMap.cs
+++ b/src/EggMapper/TypeMap.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using EggMapper.Internal;
 
 namespace EggMapper;
@@ -21,4 +22,6 @@ internal sealed class TypeMap
     public Func<object, object?, ResolutionContext, object>? ConvertUsingFunc { get; set; }
     public Func<object, object?, ResolutionContext, object>? MappingDelegate { get; set; }
     public Func<System.Reflection.PropertyInfo, bool>? ShouldMapProperty { get; set; }
+    /// <summary>The compiled expression tree, stored before .Compile() for diagnostics.</summary>
+    public LambdaExpression? MappingExpression { get; set; }
 }


### PR DESCRIPTION
## Summary
- Adds `GetMappingExpressionText<TSource, TDest>()` to `MapperConfiguration`
- Stores `LambdaExpression` on `TypeMap` before `.Compile()` in ctx-free and typed paths
- Returns the expression tree as a human-readable string — helps debug \"why is my property null?\"
- Returns `null` for flexible-path maps (no expression tree available) and `ConvertUsing` maps

## Test plan
- [x] Returns non-empty string for registered maps
- [x] Contains lambda `=>` syntax
- [x] Returns null for unregistered maps
- [x] Works for nested maps
- [x] 229 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)