### PR TITLE
feat: patch/partial mapping via mapper.Patch<S,D>() (Feature 6)

### DIFF
--- a/src/EggMapper.UnitTests/PatchMappingTests.cs
+++ b/src/EggMapper.UnitTests/PatchMappingTests.cs
@@ -1,0 +1,173 @@
+using EggMapper;
+using FluentAssertions;
+using Xunit;
+
+namespace EggMapper.UnitTests;
+
+/// <summary>
+/// Feature 6: Patch / Partial Mapping.
+/// Verifies that Patch() only overwrites destination properties where the source
+/// property is non-null (reference types) or HasValue (Nullable&lt;T&gt;).
+/// </summary>
+public class PatchMappingTests
+{
+    private class PersonPatch
+    {
+        public string? Name { get; set; }
+        public int? Age { get; set; }
+        public string? Email { get; set; }
+    }
+
+    private class PersonEntity
+    {
+        public string Name { get; set; } = "Original";
+        public int Age { get; set; } = 99;
+        public string Email { get; set; } = "original@example.com";
+    }
+
+    // ── Basic null-skipping ────────────────────────────────────────────────
+
+    [Fact]
+    public void Patch_NullSourceProps_LeavesDestinationUnchanged()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<PersonPatch, PersonEntity>());
+        var mapper = cfg.CreateMapper();
+
+        var patch = new PersonPatch { Name = null, Age = null, Email = null };
+        var dest = new PersonEntity { Name = "Alice", Age = 30, Email = "alice@example.com" };
+
+        mapper.Patch(patch, dest);
+
+        dest.Name.Should().Be("Alice");
+        dest.Age.Should().Be(30);
+        dest.Email.Should().Be("alice@example.com");
+    }
+
+    [Fact]
+    public void Patch_SomeNullSourceProps_OnlyOverwritesNonNull()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<PersonPatch, PersonEntity>());
+        var mapper = cfg.CreateMapper();
+
+        var patch = new PersonPatch { Name = "Bob", Age = null, Email = null };
+        var dest = new PersonEntity { Name = "Alice", Age = 30, Email = "alice@example.com" };
+
+        mapper.Patch(patch, dest);
+
+        dest.Name.Should().Be("Bob");
+        dest.Age.Should().Be(30);       // not overwritten
+        dest.Email.Should().Be("alice@example.com"); // not overwritten
+    }
+
+    [Fact]
+    public void Patch_AllSourcePropsSet_OverwritesAll()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<PersonPatch, PersonEntity>());
+        var mapper = cfg.CreateMapper();
+
+        var patch = new PersonPatch { Name = "Charlie", Age = 25, Email = "charlie@example.com" };
+        var dest = new PersonEntity { Name = "Alice", Age = 30, Email = "alice@example.com" };
+
+        mapper.Patch(patch, dest);
+
+        dest.Name.Should().Be("Charlie");
+        dest.Age.Should().Be(25);
+        dest.Email.Should().Be("charlie@example.com");
+    }
+
+    // ── Nullable value types ──────────────────────────────────────────────
+
+    private class UpdateDto
+    {
+        public int? Count { get; set; }
+        public decimal? Price { get; set; }
+        public bool? IsActive { get; set; }
+    }
+
+    private class Product
+    {
+        public int Count { get; set; } = 10;
+        public decimal Price { get; set; } = 9.99m;
+        public bool IsActive { get; set; } = true;
+    }
+
+    [Fact]
+    public void Patch_NullableValueTypes_OnlyOverwritesHasValue()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<UpdateDto, Product>());
+        var mapper = cfg.CreateMapper();
+
+        var dto = new UpdateDto { Count = 5, Price = null, IsActive = false };
+        var product = new Product { Count = 10, Price = 9.99m, IsActive = true };
+
+        mapper.Patch(dto, product);
+
+        product.Count.Should().Be(5);
+        product.Price.Should().Be(9.99m);    // not overwritten
+        product.IsActive.Should().BeFalse(); // overwritten with false
+    }
+
+    // ── Non-nullable value types always assigned ──────────────────────────
+
+    private class DirectUpdate
+    {
+        public int Score { get; set; }
+        public string? Label { get; set; }
+    }
+
+    private class ScoreEntity
+    {
+        public int Score { get; set; } = 100;
+        public string Label { get; set; } = "default";
+    }
+
+    [Fact]
+    public void Patch_NonNullableValueType_AlwaysAssigned()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<DirectUpdate, ScoreEntity>());
+        var mapper = cfg.CreateMapper();
+
+        // Score = 0 (non-nullable int default) → still assigned
+        var dto = new DirectUpdate { Score = 0, Label = null };
+        var entity = new ScoreEntity { Score = 100, Label = "original" };
+
+        mapper.Patch(dto, entity);
+
+        entity.Score.Should().Be(0);        // assigned even when 0
+        entity.Label.Should().Be("original"); // not overwritten (null string)
+    }
+
+    // ── Null source → destination unchanged ──────────────────────────────
+
+    [Fact]
+    public void Patch_NullSource_ReturnDestinationUnchanged()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<PersonPatch, PersonEntity>());
+        var mapper = cfg.CreateMapper();
+
+        var dest = new PersonEntity { Name = "Eve", Age = 28, Email = "eve@example.com" };
+
+        mapper.Patch<PersonPatch, PersonEntity>(null!, dest);
+
+        dest.Name.Should().Be("Eve");
+        dest.Age.Should().Be(28);
+        dest.Email.Should().Be("eve@example.com");
+    }
+
+    // ── Idempotence: calling Patch twice is safe ─────────────────────────
+
+    [Fact]
+    public void Patch_CalledTwice_SecondCallUsesCache()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<PersonPatch, PersonEntity>());
+        var mapper = cfg.CreateMapper();
+
+        var dest = new PersonEntity();
+
+        mapper.Patch(new PersonPatch { Name = "First" }, dest);
+        dest.Name.Should().Be("First");
+
+        mapper.Patch(new PersonPatch { Name = "Second" }, dest);
+        dest.Name.Should().Be("Second");
+    }
+}

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -2285,6 +2285,168 @@ internal static class ExpressionBuilder
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    // Patch / partial mapping  (Feature 6)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Builds a <c>Func&lt;TSrc, TDest, TDest&gt;</c> that copies only non-null
+    /// (reference types) or HasValue (Nullable&lt;T&gt;) source properties onto
+    /// an existing destination instance.  Non-nullable value-type source
+    /// properties are always assigned.
+    /// Returns null when the map cannot be expressed as a patch delegate
+    /// (ConvertUsing, inheritance, or collection source/dest types).
+    /// </summary>
+    public static Delegate? TryBuildPatchDelegate(TypeMap typeMap)
+    {
+        if (typeMap.ConvertUsingFunc != null) return null;
+        if (typeMap.BaseMapTypePair.HasValue) return null;
+        if (ReflectionHelper.IsCollectionType(typeMap.SourceType)) return null;
+        if (ReflectionHelper.IsCollectionType(typeMap.DestinationType)) return null;
+
+        var srcType = typeMap.SourceType;
+        var destType = typeMap.DestinationType;
+        var srcDetails = TypeDetails.Get(srcType);
+        var destDetails = TypeDetails.Get(destType);
+
+        var srcParam  = Expression.Parameter(srcType,  "src");
+        var destParam = Expression.Parameter(destType, "dest");
+        var stmts = new List<Expression>();
+
+        var processedProps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var propMap in typeMap.PropertyMaps)
+        {
+            processedProps.Add(propMap.DestinationProperty.Name);
+            if (propMap.Ignored) continue;
+
+            // Skip complex resolvers — patch only handles simple value projection
+            if (propMap.CustomResolver != null || propMap.ContextResolver != null
+                || propMap.ValueResolverFactory != null) continue;
+
+            if (propMap.HasUseValue)
+            {
+                // Fixed value — always apply
+                try
+                {
+                    stmts.Add(Expression.Assign(
+                        Expression.Property(destParam, propMap.DestinationProperty),
+                        Expression.Convert(Expression.Constant(propMap.UseValue),
+                            propMap.DestinationProperty.PropertyType)));
+                }
+                catch { }
+                continue;
+            }
+
+            if (propMap.SourceMemberName != null)
+            {
+                srcDetails.ReadableByName.TryGetValue(propMap.SourceMemberName, out var srcProp);
+                if (srcProp == null) continue;
+                var expr = TryBuildPatchAssign(srcParam, destParam, srcProp, propMap.DestinationProperty);
+                if (expr != null) stmts.Add(expr);
+            }
+        }
+
+        foreach (var destProp in destDetails.WritableProperties)
+        {
+            if (processedProps.Contains(destProp.Name)) continue;
+            processedProps.Add(destProp.Name);
+
+            srcDetails.ReadableByName.TryGetValue(destProp.Name, out var srcProp);
+            if (srcProp == null) continue;
+
+            var expr = TryBuildPatchAssign(srcParam, destParam, srcProp, destProp);
+            if (expr != null) stmts.Add(expr);
+        }
+
+        stmts.Add(destParam);
+        var body = stmts.Count == 1
+            ? (Expression)destParam
+            : Expression.Block(stmts);
+        var funcType = typeof(Func<,,>).MakeGenericType(srcType, destType, destType);
+        return Expression.Lambda(funcType, body, srcParam, destParam).Compile();
+    }
+
+    private static Expression? TryBuildPatchAssign(
+        ParameterExpression srcParam, ParameterExpression destParam,
+        PropertyInfo srcProp, PropertyInfo destProp)
+    {
+        var srcType   = srcProp.PropertyType;
+        var destType  = destProp.PropertyType;
+        var srcAccess = Expression.Property(srcParam,  srcProp);
+        var destAccess = Expression.Property(destParam, destProp);
+
+        var innerAssign = BuildPatchInnerAssign(srcAccess, destAccess, srcType, destType);
+        if (innerAssign == null) return null;
+
+        // Reference type: guard with null check
+        if (!srcType.IsValueType)
+        {
+            return Expression.IfThen(
+                Expression.ReferenceNotEqual(
+                    Expression.Convert(srcAccess, typeof(object)),
+                    Expression.Constant(null, typeof(object))),
+                innerAssign);
+        }
+
+        // Nullable<T>: guard with HasValue
+        if (Nullable.GetUnderlyingType(srcType) != null)
+        {
+            return Expression.IfThen(
+                Expression.Property(srcAccess, "HasValue"),
+                innerAssign);
+        }
+
+        // Non-nullable value type: always assign
+        return innerAssign;
+    }
+
+    private static Expression? BuildPatchInnerAssign(
+        Expression srcAccess, Expression destAccess, Type srcType, Type destType)
+    {
+        if (ReflectionHelper.IsCollectionType(srcType) || ReflectionHelper.IsCollectionType(destType))
+            return null;
+
+        var srcUnderlying  = Nullable.GetUnderlyingType(srcType);
+        var destUnderlying = Nullable.GetUnderlyingType(destType);
+
+        if (srcType == destType)
+            return Expression.Assign(destAccess, srcAccess);
+
+        if (destType.IsAssignableFrom(srcType))
+            return Expression.Assign(destAccess, Expression.Convert(srcAccess, destType));
+
+        // Nullable<T> → T: HasValue is already guarded above; use .Value
+        if (srcUnderlying != null
+            && (destType == srcUnderlying || destType.IsAssignableFrom(srcUnderlying)))
+            return Expression.Assign(destAccess,
+                Expression.Convert(Expression.Property(srcAccess, "Value"), destType));
+
+        // T → Nullable<T>
+        if (destUnderlying != null
+            && (srcType == destUnderlying || destUnderlying.IsAssignableFrom(srcType)))
+            return Expression.Assign(destAccess, Expression.Convert(srcAccess, destType));
+
+        // Enum ↔ string
+        {
+            var srcCore  = srcUnderlying  ?? srcType;
+            var destCore = destUnderlying ?? destType;
+            if (srcCore.IsEnum && destType == typeof(string))
+                return BuildEnumToStringAssign(srcAccess, destAccess, srcUnderlying);
+            if (srcType == typeof(string) && destCore.IsEnum)
+                return BuildStringToEnumAssign(srcAccess, destAccess, destType, destCore);
+        }
+
+        // Numeric value-type conversions
+        if (srcType.IsValueType && destType.IsValueType)
+        {
+            try { return Expression.Assign(destAccess, Expression.Convert(srcAccess, destType)); }
+            catch { return null; }
+        }
+
+        return null;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     // Constructor matching helpers (Feature 5: Record / parameterized-ctor support)
     // ══════════════════════════════════════════════════════════════════════════
 

--- a/src/EggMapper/IMapper.cs
+++ b/src/EggMapper/IMapper.cs
@@ -14,4 +14,11 @@ public interface IMapper
     /// using a single shared <see cref="ResolutionContext"/>, avoiding per-item allocations.
     /// </summary>
     List<TDestination> MapList<TSource, TDestination>(IEnumerable<TSource> source);
+
+    /// <summary>
+    /// Partial / patch mapping: copies only non-null (reference types) or HasValue
+    /// (Nullable&lt;T&gt;) source properties onto <paramref name="destination"/>.
+    /// Non-nullable value-type source properties are always assigned.
+    /// </summary>
+    TDestination Patch<TSource, TDestination>(TSource source, TDestination destination);
 }

--- a/src/EggMapper/Mapper.cs
+++ b/src/EggMapper/Mapper.cs
@@ -106,6 +106,34 @@ public sealed class Mapper : IMapper
     public object Map(object source, Type sourceType, Type destinationType)
         => MapInternal(source, sourceType, destinationType, null);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public TDestination Patch<TSource, TDestination>(TSource source, TDestination destination)
+    {
+        if (source == null) return destination;
+
+        var fast = PatchCache<TSource, TDestination>.Func;
+        if (fast != null & PatchCache<TSource, TDestination>.Generation == _generation)
+            return fast(source, destination);
+
+        return PatchSlow<TSource, TDestination>(source, destination);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private TDestination PatchSlow<TSource, TDestination>(TSource source, TDestination destination)
+    {
+        var key = new TypePair(typeof(TSource), typeof(TDestination));
+        if (_config.FrozenPatchMaps.TryGetValue(key, out var raw))
+        {
+            var patchDel = (Func<TSource, TDestination, TDestination>)raw;
+            PatchCache<TSource, TDestination>.Func = patchDel;
+            PatchCache<TSource, TDestination>.Generation = _generation;
+            return patchDel(source, destination);
+        }
+        throw new InvalidOperationException(
+            $"No mapping configured for {typeof(TSource).Name} -> {typeof(TDestination).Name}. " +
+            $"Call CreateMap<{typeof(TSource).Name}, {typeof(TDestination).Name}>() in your mapper configuration.");
+    }
+
     public List<TDestination> MapList<TSource, TDestination>(IEnumerable<TSource> source)
     {
         if (source == null) throw new ArgumentNullException(nameof(source));
@@ -252,6 +280,15 @@ public sealed class Mapper : IMapper
     private static class FastListCache<TSource, TDestination>
     {
         public static Func<List<TSource>, List<TDestination>>? Func;
+        public static int Generation;
+    }
+
+    /// <summary>
+    /// Lock-free single-slot global cache for Patch&lt;S,D&gt;. Zero overhead after first call.
+    /// </summary>
+    private static class PatchCache<TSource, TDestination>
+    {
+        public static Func<TSource, TDestination, TDestination>? Func;
         public static int Generation;
     }
 }

--- a/src/EggMapper/MapperConfiguration.cs
+++ b/src/EggMapper/MapperConfiguration.cs
@@ -22,6 +22,9 @@ public sealed class MapperConfiguration
     // Inlines the entire collection + element mapping loop — zero per-element delegate call.
     internal Dictionary<TypePair, Delegate> FrozenCtxFreeListMaps = null!;
 
+    // Patch delegates: Func<TSrc, TDest, TDest> — copies only non-null/HasValue props.
+    internal Dictionary<TypePair, Delegate> FrozenPatchMaps = null!;
+
     internal Func<System.Reflection.PropertyInfo, bool>? ShouldMapProperty { get; private set; }
 
     internal int DefaultMaxDepth { get; private set; }
@@ -48,14 +51,16 @@ public sealed class MapperConfiguration
         // fall back to the full typed-delegate build, then try list delegate — all in one loop.
         var ctxFree = new Dictionary<TypePair, Delegate>();
         var ctxFreeList = new Dictionary<TypePair, Delegate>();
+        var patch = new Dictionary<TypePair, Delegate>();
 
         foreach (var typeMap in TopologicalOrder(_typeMaps))
-            CompileMap(typeMap, ctxFree, ctxFreeList, DefaultMaxDepth);
+            CompileMap(typeMap, ctxFree, ctxFreeList, patch, DefaultMaxDepth);
 
         // Snapshot: no further writes will occur after construction.
         FrozenMaps = new Dictionary<TypePair, Func<object, object?, ResolutionContext, object>>(_compiledMaps);
         FrozenCtxFreeMaps = ctxFree;
         FrozenCtxFreeListMaps = ctxFreeList;
+        FrozenPatchMaps = patch;
     }
 
     private static IEnumerable<TypeMap> TopologicalOrder(Dictionary<TypePair, TypeMap> typeMaps)
@@ -91,6 +96,7 @@ public sealed class MapperConfiguration
         TypeMap typeMap,
         Dictionary<TypePair, Delegate> ctxFree,
         Dictionary<TypePair, Delegate> ctxFreeList,
+        Dictionary<TypePair, Delegate> patch,
         int defaultMaxDepth)
     {
         var key = new TypePair(typeMap.SourceType, typeMap.DestinationType);
@@ -132,6 +138,11 @@ public sealed class MapperConfiguration
         var listDel = Execution.ExpressionBuilder.TryBuildCtxFreeListDelegate(typeMap, _typeMaps);
         if (listDel != null)
             ctxFreeList[key] = listDel;
+
+        // Patch delegate — null-guarded partial mapping.
+        var patchDel = Execution.ExpressionBuilder.TryBuildPatchDelegate(typeMap);
+        if (patchDel != null)
+            patch[key] = patchDel;
     }
 
     private void ResolveIncludeAllDerived()


### PR DESCRIPTION
## Summary

- `mapper.Patch<TSource, TDestination>(source, destination)` merges only non-null/non-default source values onto an existing destination instance
- Reference-type source props: guarded with `if (src.Prop != null)` 
- `Nullable<T>` source props: guarded with `if (src.Prop.HasValue)`
- Non-nullable value-type props: always assigned (can't detect absence in a value type)
- Null source → destination returned unchanged

## Changes

- `IMapper`: new `Patch<TSource, TDestination>(TSource, TDestination)` method
- `ExpressionBuilder.TryBuildPatchDelegate()`: compiles a `Func<TSrc,TDest,TDest>` with null-guarded conditional assignments
- `MapperConfiguration.FrozenPatchMaps`: stores compiled patch delegates (frozen at config time)
- `Mapper.Patch<>`: generation-tagged `PatchCache<S,D>` for zero-overhead repeated calls
- 7 new tests in `PatchMappingTests.cs`

## Test plan

- [x] All 255 existing tests pass across net8/net9/net10
- [x] 7 new patch-mapping tests pass

Closes part of #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)