### PR TITLE
feat: inline validation during mapping (.Validate() API) (Feature 7)

### DIFF
--- a/src/EggMapper.UnitTests/InlineValidationTests.cs
+++ b/src/EggMapper.UnitTests/InlineValidationTests.cs
@@ -1,0 +1,156 @@
+using EggMapper;
+using FluentAssertions;
+using Xunit;
+
+namespace EggMapper.UnitTests;
+
+/// <summary>
+/// Feature 7: Inline Validation During Mapping.
+/// Validates that .Validate() rules are evaluated after mapping and that
+/// MappingValidationException is thrown with all collected violations.
+/// </summary>
+public class InlineValidationTests
+{
+    private class UserSrc
+    {
+        public string Email { get; set; } = "";
+        public int Age { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class UserDest
+    {
+        public string Email { get; set; } = "";
+        public int Age { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    // ── Single rule passes ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Map_ValidSource_DoesNotThrow()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserDest>()
+             .Validate(x => x.Email, e => e.Contains("@"), "Email must contain @"));
+        var mapper = cfg.CreateMapper();
+
+        var act = () => mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "alice@example.com", Age = 30, Name = "Alice" });
+
+        act.Should().NotThrow();
+    }
+
+    // ── Single rule fails ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Map_InvalidSource_ThrowsMappingValidationException()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserDest>()
+             .Validate(x => x.Email, e => e.Contains("@"), "Email must contain @"));
+        var mapper = cfg.CreateMapper();
+
+        var act = () => mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "not-an-email", Age = 30, Name = "Bob" });
+
+        act.Should().Throw<MappingValidationException>()
+           .Which.Errors.Should().ContainSingle()
+           .Which.Should().Be("Email must contain @");
+    }
+
+    // ── Multiple rules — all failures collected ───────────────────────────
+
+    [Fact]
+    public void Map_MultipleFailures_AllCollectedInException()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserDest>()
+             .Validate(x => x.Email, e => e.Contains("@"), "Email must contain @")
+             .Validate(x => x.Age,   a => a >= 18,          "Age must be 18 or older")
+             .Validate(x => x.Name,  n => n.Length > 0,     "Name must not be empty"));
+        var mapper = cfg.CreateMapper();
+
+        var act = () => mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "bad", Age = 16, Name = "" });
+
+        var ex = act.Should().Throw<MappingValidationException>().Which;
+        ex.Errors.Should().HaveCount(3);
+        ex.Errors.Should().Contain("Email must contain @");
+        ex.Errors.Should().Contain("Age must be 18 or older");
+        ex.Errors.Should().Contain("Name must not be empty");
+    }
+
+    // ── Partial failures — only failed rules in exception ─────────────────
+
+    [Fact]
+    public void Map_SomeRulesFail_OnlyFailedRulesInErrors()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserDest>()
+             .Validate(x => x.Email, e => e.Contains("@"), "Invalid email")
+             .Validate(x => x.Age,   a => a >= 18,          "Underage")
+             .Validate(x => x.Name,  n => n.Length > 0,     "Name required"));
+        var mapper = cfg.CreateMapper();
+
+        var act = () => mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "alice@example.com", Age = 16, Name = "Alice" });
+
+        var ex = act.Should().Throw<MappingValidationException>().Which;
+        ex.Errors.Should().ContainSingle().Which.Should().Be("Underage");
+    }
+
+    // ── Zero-cost when no validators ──────────────────────────────────────
+
+    [Fact]
+    public void Map_NoValidators_UsesCtxFreePath_NoThrow()
+    {
+        // Without Validate(), the map uses the fast ctx-free path — just verify it still works.
+        var cfg = new MapperConfiguration(c => c.CreateMap<UserSrc, UserDest>());
+        var mapper = cfg.CreateMapper();
+
+        var dest = mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "alice@example.com", Age = 30, Name = "Alice" });
+
+        dest.Email.Should().Be("alice@example.com");
+        dest.Age.Should().Be(30);
+    }
+
+    // ── Exception message includes all violations ─────────────────────────
+
+    [Fact]
+    public void MappingValidationException_MessageContainsAllViolations()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserDest>()
+             .Validate(x => x.Email, e => e.Contains("@"), "Bad email")
+             .Validate(x => x.Age,   a => a >= 18,          "Underage"));
+        var mapper = cfg.CreateMapper();
+
+        var act = () => mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "bad", Age = 16, Name = "X" });
+
+        var ex = act.Should().Throw<MappingValidationException>().Which;
+        ex.Message.Should().Contain("Bad email");
+        ex.Message.Should().Contain("Underage");
+    }
+
+    // ── All rules pass → no exception ────────────────────────────────────
+
+    [Fact]
+    public void Map_AllRulesPass_ReturnsCorrectlyMappedDest()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserDest>()
+             .Validate(x => x.Email, e => e.Contains("@"), "Invalid email")
+             .Validate(x => x.Age,   a => a > 0,            "Invalid age"));
+        var mapper = cfg.CreateMapper();
+
+        var dest = mapper.Map<UserSrc, UserDest>(
+            new UserSrc { Email = "test@test.com", Age = 25, Name = "Test" });
+
+        dest.Email.Should().Be("test@test.com");
+        dest.Age.Should().Be(25);
+        dest.Name.Should().Be("Test");
+    }
+}

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -126,6 +126,7 @@ internal static class ExpressionBuilder
         if (typeMap.AfterMapCtxAction  != null) return null;
         if (typeMap.MaxDepth > 0) return null;
         if (typeMap.BaseMapTypePair.HasValue) return null;
+        if (typeMap.ValidationRules?.Count > 0) return null;  // validators need flexible path
         if (ReflectionHelper.IsCollectionType(typeMap.SourceType)) return null;
         if (ReflectionHelper.IsCollectionType(typeMap.DestinationType)) return null;
 
@@ -875,6 +876,7 @@ internal static class ExpressionBuilder
         if (typeMap.BaseMapTypePair.HasValue) return false;
         if (typeMap.ConvertUsingFunc != null) return false;
         if (typeMap.ShouldMapProperty != null) return false;
+        if (typeMap.ValidationRules?.Count > 0) return false;  // validators need flexible path
         if (ReflectionHelper.IsCollectionType(typeMap.SourceType)) return false;
         if (ReflectionHelper.IsCollectionType(typeMap.DestinationType)) return false;
 
@@ -1682,6 +1684,7 @@ internal static class ExpressionBuilder
         var afterMapCtx = typeMap.AfterMapCtxAction;
         // Per-map MaxDepth takes precedence; fall back to global default as safety net.
         var maxDepth = typeMap.MaxDepth > 0 ? typeMap.MaxDepth : defaultMaxDepth;
+        var validationRules = typeMap.ValidationRules;
 
         return (object src, object? dest, ResolutionContext ctx) =>
         {
@@ -1708,6 +1711,27 @@ internal static class ExpressionBuilder
 
                 afterMap?.Invoke(src, typedDest);
                 afterMapCtx?.Invoke(src, typedDest, ctx);
+
+                // Inline validation — collect all violations before throwing
+                if (validationRules != null && validationRules.Count > 0)
+                {
+                    List<string>? violations = null;
+                    for (int i = 0; i < validationRules.Count; i++)
+                    {
+                        var (predicate, message) = validationRules[i];
+                        if (!predicate(typedDest))
+                        {
+                            violations ??= new List<string>();
+                            violations.Add(message);
+                        }
+                    }
+                    if (violations != null)
+                        throw new MappingValidationException(violations);
+                }
+            }
+            catch (MappingValidationException)
+            {
+                throw;
             }
             catch (MappingException)
             {

--- a/src/EggMapper/IMappingExpression.cs
+++ b/src/EggMapper/IMappingExpression.cs
@@ -36,6 +36,18 @@ public interface IMappingExpression<TSource, TDestination>
 
     IMappingExpression<TSource, TDestination> ForAllMembers(
         Action<IMemberConfigurationExpression<TSource, TDestination, object>> memberOptions);
+
+    /// <summary>
+    /// Adds an inline validation rule that runs after all properties are mapped.
+    /// If <paramref name="predicate"/> returns false for the mapped destination value,
+    /// <paramref name="errorMessage"/> is collected and thrown as part of a
+    /// <see cref="MappingValidationException"/> once all rules have been evaluated.
+    /// Maps with validation rules are routed to the flexible delegate path.
+    /// </summary>
+    IMappingExpression<TSource, TDestination> Validate<TMember>(
+        Expression<Func<TDestination, TMember>> destinationMember,
+        Func<TMember, bool> predicate,
+        string errorMessage);
 }
 
 /// <summary>

--- a/src/EggMapper/MapperConfigurationExpression.cs
+++ b/src/EggMapper/MapperConfigurationExpression.cs
@@ -257,6 +257,19 @@ internal sealed class MappingExpression<TSource, TDestination> : IMappingExpress
         }
         return this;
     }
+
+    public IMappingExpression<TSource, TDestination> Validate<TMember>(
+        Expression<Func<TDestination, TMember>> destinationMember,
+        Func<TMember, bool> predicate,
+        string errorMessage)
+    {
+        var compiled = destinationMember.Compile();
+        _typeMap.ValidationRules ??= new();
+        _typeMap.ValidationRules.Add((
+            obj => predicate(compiled((TDestination)obj)),
+            errorMessage));
+        return this;
+    }
 }
 
 internal sealed class MemberConfigurationExpression<TSource, TDestination, TMember>

--- a/src/EggMapper/MappingValidationException.cs
+++ b/src/EggMapper/MappingValidationException.cs
@@ -1,0 +1,17 @@
+namespace EggMapper;
+
+/// <summary>
+/// Thrown when one or more inline validation rules fail during mapping.
+/// All violations are collected before throwing so callers see the complete picture.
+/// </summary>
+public sealed class MappingValidationException : Exception
+{
+    /// <summary>All validation error messages collected during the mapping pass.</summary>
+    public IReadOnlyList<string> Errors { get; }
+
+    public MappingValidationException(IReadOnlyList<string> errors)
+        : base("Mapping validation failed:\n" + string.Join("\n", errors.Select(e => $"  - {e}")))
+    {
+        Errors = errors;
+    }
+}

--- a/src/EggMapper/TypeMap.cs
+++ b/src/EggMapper/TypeMap.cs
@@ -24,4 +24,11 @@ internal sealed class TypeMap
     public Func<System.Reflection.PropertyInfo, bool>? ShouldMapProperty { get; set; }
     /// <summary>The compiled expression tree, stored before .Compile() for diagnostics.</summary>
     public LambdaExpression? MappingExpression { get; set; }
+
+    /// <summary>
+    /// Inline validation rules added via .Validate(). Each entry is a (predicate, errorMessage)
+    /// pair where the predicate receives the fully-mapped destination object (boxed as object).
+    /// Maps with validators are routed to the flexible path (zero overhead when list is null).
+    /// </summary>
+    public List<(Func<object, bool> Predicate, string Message)>? ValidationRules { get; set; }
 }


### PR DESCRIPTION
## Summary

- `.Validate(x => x.Email, e => e.Contains("@"), "Invalid email")` fluent API on `IMappingExpression<S,D>`
- All validation rules are evaluated after full property mapping; all failures collected before throwing
- `MappingValidationException` carries `Errors: IReadOnlyList<string>` with all violation messages
- **Zero overhead when unused**: maps without `.Validate()` stay on the fast ctx-free path

## Changes

- `MappingValidationException`: new exception type with collected `Errors` list
- `TypeMap.ValidationRules`: `List<(Func<object,bool>, string)>?` stored at configuration time
- `IMappingExpression<S,D>.Validate<TMember>`: new fluent interface method
- `TryBuildCtxFreeDelegate` + `TryBuildTypedDelegate`: bail to flexible path when validators exist
- `BuildFlexibleDelegate`: runs all validators post-afterMap; rethrows `MappingValidationException` directly
- 7 new tests in `InlineValidationTests.cs`

## Test plan

- [x] All 262 existing tests pass across net8/net9/net10
- [x] 7 new inline-validation tests pass

Closes part of #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)