### PR TITLE
feat: ProjectTo / IQueryable projection (Feature 8)

### DIFF
--- a/src/EggMapper.UnitTests/ProjectToTests.cs
+++ b/src/EggMapper.UnitTests/ProjectToTests.cs
@@ -1,0 +1,202 @@
+using EggMapper;
+using FluentAssertions;
+using Xunit;
+
+namespace EggMapper.UnitTests;
+
+/// <summary>
+/// Feature 8: ProjectTo / IQueryable projection.
+/// Validates that BuildProjection and ProjectTo produce correct expression trees
+/// and return the right data when executed via LINQ-to-objects.
+/// </summary>
+public class ProjectToTests
+{
+    // ── Source / destination types ─────────────────────────────────────────
+
+    private class UserSrc
+    {
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+        public string Email { get; set; } = "";
+        public AddressSrc Address { get; set; } = new();
+    }
+
+    private class AddressSrc
+    {
+        public string Street { get; set; } = "";
+        public string City { get; set; } = "";
+    }
+
+    private class UserDto
+    {
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+        public string Email { get; set; } = "";
+    }
+
+    private class UserWithAddressDto
+    {
+        public string Name { get; set; } = "";
+        public AddressDto Address { get; set; } = new();
+    }
+
+    private class AddressDto
+    {
+        public string Street { get; set; } = "";
+        public string City { get; set; } = "";
+    }
+
+    private class UserFlatDto
+    {
+        public string Name { get; set; } = "";
+        public string AddressStreet { get; set; } = "";
+        public string AddressCity { get; set; } = "";
+    }
+
+    private class UserCustomDto
+    {
+        public string DisplayName { get; set; } = "";
+        public int Age { get; set; }
+    }
+
+    private record UserRecord(string Name, int Age);
+
+    // ── Basic flat projection ──────────────────────────────────────────────
+
+    [Fact]
+    public void ProjectTo_BasicFlat_MapsCorrectly()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<UserSrc, UserDto>());
+
+        var source = new List<UserSrc>
+        {
+            new() { Name = "Alice", Age = 30, Email = "alice@example.com" },
+            new() { Name = "Bob",   Age = 25, Email = "bob@example.com" }
+        }.AsQueryable();
+
+        var result = source.ProjectTo<UserSrc, UserDto>(cfg).ToList();
+
+        result.Should().HaveCount(2);
+        result[0].Name.Should().Be("Alice");
+        result[0].Age.Should().Be(30);
+        result[0].Email.Should().Be("alice@example.com");
+        result[1].Name.Should().Be("Bob");
+        result[1].Age.Should().Be(25);
+    }
+
+    // ── Nested DTO projection ──────────────────────────────────────────────
+
+    [Fact]
+    public void ProjectTo_NestedDto_MapsNestedObjectCorrectly()
+    {
+        var cfg = new MapperConfiguration(c =>
+        {
+            c.CreateMap<AddressSrc, AddressDto>();
+            c.CreateMap<UserSrc, UserWithAddressDto>();
+        });
+
+        var source = new List<UserSrc>
+        {
+            new() { Name = "Alice", Address = new() { Street = "Main St", City = "Springfield" } }
+        }.AsQueryable();
+
+        var result = source.ProjectTo<UserSrc, UserWithAddressDto>(cfg).ToList();
+
+        result[0].Name.Should().Be("Alice");
+        result[0].Address.Street.Should().Be("Main St");
+        result[0].Address.City.Should().Be("Springfield");
+    }
+
+    // ── Flattened projection ───────────────────────────────────────────────
+
+    [Fact]
+    public void ProjectTo_FlattenedProperties_MapsCorrectly()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<UserSrc, UserFlatDto>());
+
+        var source = new List<UserSrc>
+        {
+            new() { Name = "Alice", Address = new() { Street = "Elm St", City = "Shelbyville" } }
+        }.AsQueryable();
+
+        var result = source.ProjectTo<UserSrc, UserFlatDto>(cfg).ToList();
+
+        result[0].Name.Should().Be("Alice");
+        result[0].AddressStreet.Should().Be("Elm St");
+        result[0].AddressCity.Should().Be("Shelbyville");
+    }
+
+    // ── Custom MapFrom expression ──────────────────────────────────────────
+
+    [Fact]
+    public void ProjectTo_CustomMapFrom_UsesStoredExpression()
+    {
+        var cfg = new MapperConfiguration(c =>
+            c.CreateMap<UserSrc, UserCustomDto>()
+             .ForMember(d => d.DisplayName, o => o.MapFrom(s => s.Name + " (user)")));
+
+        var source = new List<UserSrc>
+        {
+            new() { Name = "Alice", Age = 30 }
+        }.AsQueryable();
+
+        var result = source.ProjectTo<UserSrc, UserCustomDto>(cfg).ToList();
+
+        result[0].DisplayName.Should().Be("Alice (user)");
+        result[0].Age.Should().Be(30);
+    }
+
+    // ── Record (parameterized ctor) projection ─────────────────────────────
+
+    [Fact]
+    public void ProjectTo_RecordDestination_MapsViaConstructor()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<UserSrc, UserRecord>());
+
+        var source = new List<UserSrc>
+        {
+            new() { Name = "Alice", Age = 30 },
+            new() { Name = "Bob",   Age = 25 }
+        }.AsQueryable();
+
+        var result = source.ProjectTo<UserSrc, UserRecord>(cfg).ToList();
+
+        result[0].Name.Should().Be("Alice");
+        result[0].Age.Should().Be(30);
+        result[1].Name.Should().Be("Bob");
+        result[1].Age.Should().Be(25);
+    }
+
+    // ── BuildProjection returns a non-null expression ──────────────────────
+
+    [Fact]
+    public void BuildProjection_ReturnsNonNullExpression()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<UserSrc, UserDto>());
+
+        var expr = cfg.BuildProjection<UserSrc, UserDto>();
+
+        expr.Should().NotBeNull();
+    }
+
+    // ── Multiple items projected correctly ────────────────────────────────
+
+    [Fact]
+    public void ProjectTo_MultipleItems_AllMappedCorrectly()
+    {
+        var cfg = new MapperConfiguration(c => c.CreateMap<UserSrc, UserDto>());
+
+        var source = Enumerable.Range(1, 5)
+            .Select(i => new UserSrc { Name = $"User{i}", Age = 20 + i })
+            .AsQueryable();
+
+        var result = source.ProjectTo<UserSrc, UserDto>(cfg).ToList();
+
+        result.Should().HaveCount(5);
+        for (int i = 0; i < 5; i++)
+        {
+            result[i].Name.Should().Be($"User{i + 1}");
+            result[i].Age.Should().Be(21 + i);
+        }
+    }
+}

--- a/src/EggMapper/Execution/ProjectionBuilder.cs
+++ b/src/EggMapper/Execution/ProjectionBuilder.cs
@@ -1,0 +1,210 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using EggMapper.Internal;
+
+namespace EggMapper.Execution;
+
+/// <summary>
+/// Builds <see cref="Expression{TDelegate}"/> projection trees suitable for LINQ providers
+/// (e.g. EF Core). The tree is never compiled by EggMapper — it is passed directly to
+/// <c>IQueryable.Select()</c> so the provider can translate it to SQL or another query DSL.
+/// </summary>
+internal static class ProjectionBuilder
+{
+    internal static Expression<Func<TSrc, TDest>> Build<TSrc, TDest>(MapperConfiguration config)
+    {
+        var srcParam = Expression.Parameter(typeof(TSrc), "src");
+        var body = BuildExpression(typeof(TSrc), typeof(TDest), srcParam, config);
+        return Expression.Lambda<Func<TSrc, TDest>>(body, srcParam);
+    }
+
+    private static Expression BuildExpression(
+        Type srcType, Type destType, Expression srcExpr, MapperConfiguration config)
+    {
+        var key = new TypePair(srcType, destType);
+        config.TypeMaps.TryGetValue(key, out var typeMap);
+
+        var destDetails = TypeDetails.Get(destType);
+        var srcDetails = TypeDetails.Get(srcType);
+        var bindings = new List<MemberBinding>();
+
+        foreach (var destProp in destDetails.WritableProperties)
+        {
+            var propMap = typeMap?.PropertyMaps.FirstOrDefault(p =>
+                p.DestinationProperty.Name == destProp.Name);
+            if (propMap?.Ignored == true) continue;
+
+            Expression? valueExpr;
+
+            if (propMap?.MapFromExpression != null)
+            {
+                // Inline the stored lambda: replace its parameter with our source expression
+                var replacer = new ParameterReplacer(propMap.MapFromExpression.Parameters[0], srcExpr);
+                valueExpr = replacer.Visit(propMap.MapFromExpression.Body);
+                if (valueExpr!.Type != destProp.PropertyType)
+                    valueExpr = Expression.Convert(valueExpr, destProp.PropertyType);
+            }
+            else if (propMap?.HasUseValue == true)
+            {
+                valueExpr = Expression.Constant(propMap.UseValue, destProp.PropertyType);
+            }
+            else
+            {
+                var srcMemberName = propMap?.SourceMemberName ?? destProp.Name;
+                if (srcDetails.ReadableByName.TryGetValue(srcMemberName, out var srcProp))
+                {
+                    var srcAccess = Expression.Property(srcExpr, srcProp);
+                    var nestedKey = new TypePair(srcProp.PropertyType, destProp.PropertyType);
+
+                    if (srcProp.PropertyType != destProp.PropertyType &&
+                        config.TypeMaps.ContainsKey(nestedKey))
+                    {
+                        // Recurse for registered nested map
+                        valueExpr = BuildExpression(srcProp.PropertyType, destProp.PropertyType,
+                            srcAccess, config);
+                    }
+                    else if (srcProp.PropertyType == destProp.PropertyType)
+                    {
+                        valueExpr = srcAccess;
+                    }
+                    else if (destProp.PropertyType.IsAssignableFrom(srcProp.PropertyType))
+                    {
+                        valueExpr = Expression.Convert(srcAccess, destProp.PropertyType);
+                    }
+                    else
+                    {
+                        continue; // incompatible types — skip
+                    }
+                }
+                else
+                {
+                    // Try flattening: dest.AddressStreet → src.Address.Street
+                    valueExpr = TryBuildFlattenedExpr(destProp.Name, destProp.PropertyType,
+                        srcExpr, srcDetails);
+                    if (valueExpr == null) continue;
+                }
+            }
+
+            bindings.Add(Expression.Bind(destProp, valueExpr));
+        }
+
+        // Parameterless ctor → MemberInitExpression
+        if (destDetails.ParameterlessCtor != null)
+            return Expression.MemberInit(Expression.New(destDetails.ParameterlessCtor), bindings);
+
+        // Parameterized ctor (records etc.) → NewExpression with member associations
+        var best = FindBestCtor(destDetails, srcDetails)
+            ?? throw new InvalidOperationException(
+                $"ProjectTo: no suitable constructor found for '{destType.Name}'.");
+
+        var ctorArgs = BuildCtorArgExpressions(best.Params, srcExpr, srcDetails);
+
+        // Associate each ctor arg with its corresponding property so LINQ providers can
+        // translate the constructor call back to member accesses.
+        var members = best.Params
+            .Select(p => (MemberInfo?)GetMatchingProperty(destDetails, p))
+            .ToArray();
+
+        var newExpr = Expression.New(best.Ctor, ctorArgs, members!);
+
+        // Include any remaining writable properties that aren't covered by ctor params
+        var ctorParamNames = new HashSet<string>(
+            best.Params.Select(p => p.Name ?? ""), StringComparer.OrdinalIgnoreCase);
+        var extraBindings = bindings
+            .Where(b => !ctorParamNames.Contains(b.Member.Name))
+            .ToList();
+
+        return extraBindings.Count > 0
+            ? (Expression)Expression.MemberInit(newExpr, extraBindings)
+            : newExpr;
+    }
+
+    private static Expression? TryBuildFlattenedExpr(
+        string destPropName, Type destPropType, Expression srcExpr, TypeDetails srcDetails)
+    {
+        foreach (var srcProp in srcDetails.ReadableProperties)
+        {
+            if (!destPropName.StartsWith(srcProp.Name, StringComparison.OrdinalIgnoreCase))
+                continue;
+            var remainder = destPropName.Substring(srcProp.Name.Length);
+            if (string.IsNullOrEmpty(remainder)) continue;
+            var nestedDetails = TypeDetails.Get(srcProp.PropertyType);
+            if (!nestedDetails.ReadableByName.TryGetValue(remainder, out var nestedProp))
+                continue;
+            var access = Expression.Property(Expression.Property(srcExpr, srcProp), nestedProp);
+            if (nestedProp.PropertyType == destPropType) return access;
+            if (destPropType.IsAssignableFrom(nestedProp.PropertyType))
+                return Expression.Convert(access, destPropType);
+        }
+        return null;
+    }
+
+    private static (ConstructorInfo Ctor, ParameterInfo[] Params)? FindBestCtor(
+        TypeDetails destDetails, TypeDetails srcDetails)
+    {
+        ConstructorInfo? best = null;
+        ParameterInfo[]? bestParams = null;
+        int bestScore = 0;
+        foreach (var ctor in destDetails.Constructors)
+        {
+            var pars = ctor.GetParameters();
+            if (pars.Length == 0) continue;
+            int score = 0;
+            foreach (var p in pars)
+                if (p.Name != null && srcDetails.ReadableByName.ContainsKey(p.Name)) score++;
+            if (score > bestScore) { bestScore = score; best = ctor; bestParams = pars; }
+        }
+        return best == null ? null : (best, bestParams!);
+    }
+
+    private static Expression[] BuildCtorArgExpressions(
+        ParameterInfo[] ctorParams, Expression srcExpr, TypeDetails srcDetails)
+    {
+        var args = new Expression[ctorParams.Length];
+        for (int i = 0; i < ctorParams.Length; i++)
+        {
+            var p = ctorParams[i];
+            if (p.Name != null && srcDetails.ReadableByName.TryGetValue(p.Name, out var srcProp))
+            {
+                var access = Expression.Property(srcExpr, srcProp);
+                if (srcProp.PropertyType == p.ParameterType)
+                    args[i] = access;
+                else if (p.ParameterType.IsAssignableFrom(srcProp.PropertyType))
+                    args[i] = Expression.Convert(access, p.ParameterType);
+                else
+                    args[i] = Expression.Default(p.ParameterType);
+            }
+            else
+            {
+                args[i] = Expression.Default(p.ParameterType);
+            }
+        }
+        return args;
+    }
+
+    private static PropertyInfo? GetMatchingProperty(TypeDetails destDetails, ParameterInfo p)
+    {
+        if (p.Name != null && destDetails.ReadableByName.TryGetValue(p.Name, out var prop))
+            return prop;
+        return null;
+    }
+}
+
+/// <summary>
+/// Replaces all occurrences of one <see cref="ParameterExpression"/> with another
+/// <see cref="Expression"/> inside an expression tree.
+/// </summary>
+internal sealed class ParameterReplacer : ExpressionVisitor
+{
+    private readonly ParameterExpression _toReplace;
+    private readonly Expression _replacement;
+
+    internal ParameterReplacer(ParameterExpression toReplace, Expression replacement)
+    {
+        _toReplace = toReplace;
+        _replacement = replacement;
+    }
+
+    protected override Expression VisitParameter(ParameterExpression node)
+        => node == _toReplace ? _replacement : base.VisitParameter(node);
+}

--- a/src/EggMapper/MapperConfiguration.cs
+++ b/src/EggMapper/MapperConfiguration.cs
@@ -183,6 +183,17 @@ public sealed class MapperConfiguration
     internal Dictionary<TypePair, TypeMap> TypeMaps => _typeMaps;
 
     /// <summary>
+    /// Builds an <see cref="System.Linq.Expressions.Expression{TDelegate}"/> that projects
+    /// <typeparamref name="TSource"/> to <typeparamref name="TDestination"/> using the
+    /// registered type map. The expression is suitable for use with LINQ providers (e.g.
+    /// EF Core) and is never compiled by EggMapper — pass it directly to
+    /// <c>IQueryable.Select()</c> or use the <c>ProjectTo</c> extension method.
+    /// </summary>
+    public System.Linq.Expressions.Expression<Func<TSource, TDestination>>
+        BuildProjection<TSource, TDestination>()
+        => Execution.ProjectionBuilder.Build<TSource, TDestination>(this);
+
+    /// <summary>
     /// Returns a human-readable string representation of the compiled expression tree
     /// for the <typeparamref name="TSource"/> → <typeparamref name="TDestination"/> map.
     /// Returns null when no expression tree is available (e.g. flexible delegate path or

--- a/src/EggMapper/MapperConfigurationExpression.cs
+++ b/src/EggMapper/MapperConfigurationExpression.cs
@@ -284,6 +284,7 @@ internal sealed class MemberConfigurationExpression<TSource, TDestination, TMemb
 
     public void MapFrom<TSourceMember>(Expression<Func<TSource, TSourceMember>> mapExpression)
     {
+        _propMap.MapFromExpression = mapExpression;
         var compiled = mapExpression.Compile();
         _propMap.CustomResolver = (src, dest) => compiled((TSource)src);
     }
@@ -370,6 +371,7 @@ internal sealed class PathConfigurationExpression<TSource, TDestination, TMember
 
     public void MapFrom<TSourceMember>(Expression<Func<TSource, TSourceMember>> mapExpression)
     {
+        _propMap.MapFromExpression = mapExpression;
         var compiled = mapExpression.Compile();
         _propMap.CustomResolver = (src, dest) => compiled((TSource)src);
     }

--- a/src/EggMapper/PropertyMap.cs
+++ b/src/EggMapper/PropertyMap.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace EggMapper;
@@ -20,4 +21,6 @@ internal sealed class PropertyMap
     public string? SourceMemberName { get; set; }
     // DI-based value resolver factory: (IServiceProvider) => resolver func
     public Func<IServiceProvider, Func<object, object?, object?, ResolutionContext, object?>>? ValueResolverFactory { get; set; }
+    /// <summary>Original uncompiled lambda — used by ProjectionBuilder to build LINQ-translatable expressions.</summary>
+    public LambdaExpression? MapFromExpression { get; set; }
 }

--- a/src/EggMapper/QueryableExtensions.cs
+++ b/src/EggMapper/QueryableExtensions.cs
@@ -1,0 +1,22 @@
+namespace EggMapper;
+
+/// <summary>
+/// LINQ extension methods for projecting <see cref="IQueryable{T}"/> sequences
+/// using registered EggMapper type maps.
+/// </summary>
+public static class QueryableExtensions
+{
+    /// <summary>
+    /// Projects each element of <paramref name="source"/> to a
+    /// <typeparamref name="TDestination"/> using the type map registered in
+    /// <paramref name="config"/>. The projection is built as a pure expression tree
+    /// and passed directly to the LINQ provider — no runtime reflection in the query
+    /// pipeline, and <c>.Compile()</c> is never called by EggMapper.
+    /// </summary>
+    public static IQueryable<TDestination> ProjectTo<TSource, TDestination>(
+        this IQueryable<TSource> source, MapperConfiguration config)
+    {
+        var projection = config.BuildProjection<TSource, TDestination>();
+        return source.Select(projection);
+    }
+}


### PR DESCRIPTION
## Summary

- **`ProjectionBuilder`** — builds `Expression<Func<TSrc, TDest>>` entirely from registered type maps; never calls `.Compile()` so LINQ providers (EF Core, etc.) can translate to SQL
- **`QueryableExtensions.ProjectTo<S,D>(config)`** — passes the built expression directly to `IQueryable.Select()`
- **`MapperConfiguration.BuildProjection<S,D>()`** — public entry point for building projection expressions
- Stores the original `MapFromExpression` on `PropertyMap` so custom lambdas are inlined into the projection tree rather than compiled to delegates

### Projection features
| Scenario | Support |
|---|---|
| Flat DTO (parameterless ctor) | `MemberInitExpression` |
| Record / parameterized ctor | `NewExpression` with member associations |
| Nested registered maps | Recursive `BuildExpression` |
| Flattened properties (`AddressStreet` → `Address.Street`) | Inline property chain |
| Custom `MapFrom` expressions | Inlined via `ParameterReplacer` |

## Test plan

- [x] `ProjectTo_BasicFlat_MapsCorrectly`
- [x] `ProjectTo_NestedDto_MapsNestedObjectCorrectly`
- [x] `ProjectTo_FlattenedProperties_MapsCorrectly`
- [x] `ProjectTo_CustomMapFrom_UsesStoredExpression`
- [x] `ProjectTo_RecordDestination_MapsViaConstructor`
- [x] `BuildProjection_ReturnsNonNullExpression`
- [x] `ProjectTo_MultipleItems_AllMappedCorrectly`
- [x] 269/269 tests green on net8.0 / net9.0 / net10.0

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)