### PR TITLE
feat: auto-update README features list and wiki docs on every release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,6 +204,19 @@ jobs:
             --generate-notes \
             ./artifacts/*.nupkg ./artifacts/*.snupkg
 
+      # ── Update README features list and wiki docs ─────────────────────────
+      - name: Update feature docs
+        if: steps.tag_check.outputs.ALREADY_TAGGED == 'false'
+        shell: bash
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          bash scripts/update-features.sh
+          git add README.md docs/Advanced-Features.md
+          git diff --cached --quiet \
+            && echo "Feature docs already up-to-date — nothing to commit." \
+            || git commit -m "docs: update features list for v${{ steps.version.outputs.VERSION }} [skip ci]"
+
       # ── Commit bumped version back to main ───────────────────────────────
       - name: Commit version bump
         if: steps.tag_check.outputs.ALREADY_TAGGED == 'false'

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 
 ## Features
 
+<!-- FEATURES_START -->
 - ✅ Compiled expression tree delegates (zero runtime reflection)
 - ✅ `ForMember` / `MapFrom` custom mappings
 - ✅ `Ignore()` members
@@ -215,7 +216,7 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 - ✅ Nested object mapping (inlined into parent expression tree)
 - ✅ Collection mapping (`List<T>`, arrays, `HashSet<T>`, etc.)
 - ✅ Flattening (`src.Address.Street` → `dest.AddressStreet`)
-- ✅ Constructor mapping
+- ✅ Constructor mapping (auto-detects best-matching constructor for records)
 - ✅ Profile-based configuration
 - ✅ Assembly scanning
 - ✅ Before/After map hooks
@@ -230,6 +231,10 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 - ✅ `CreateMap(Type, Type)` runtime type mapping
 - ✅ `ITypeConverter<S,D>` / `ConvertUsing` custom converters
 - ✅ `ShouldMapProperty` global property filter
+- ✅ Patch / partial mapping via `mapper.Patch<S,D>(src, dest)`
+- ✅ Inline validation rules via `.Validate()` (collects all failures before throwing)
+- ✅ IQueryable projection via `ProjectTo<S,D>(config)` for EF Core / LINQ providers
+<!-- FEATURES_END -->
 
 ## Documentation
 

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -196,3 +196,94 @@ Validate at startup (or in tests) that every destination property is covered:
 config.AssertConfigurationIsValid();
 // Throws if any destination property is unmapped and not ignored
 ```
+
+---
+
+## Record and Constructor Mapping
+
+EggMapper automatically selects the best-matching constructor when the destination type has no parameterless constructor. It scores constructors by how many parameter names match source property names (case-insensitive) and picks the highest-scoring one.
+
+```csharp
+public record OrderDto(int Id, string CustomerName, decimal Total);
+
+cfg.CreateMap<Order, OrderDto>();
+// Automatically calls: new OrderDto(src.Id, src.CustomerName, src.Total)
+```
+
+Any destination properties that exist on the constructor are set via it; remaining writable properties are set afterward. This works for C# records, immutable value objects, and any class with a parameterized constructor.
+
+---
+
+## Patch / Partial Mapping
+
+`mapper.Patch<TSource, TDestination>(source, destination)` copies only the *set* properties from `source` onto an existing `destination` object:
+
+- **Reference types** (`string`, classes) — copied only when the source value is non-null
+- **`Nullable<T>`** — copied only when `.HasValue` is true
+- **Non-nullable value types** (`int`, `bool`, etc.) — always copied (no sentinel for "not set")
+
+```csharp
+cfg.CreateMap<UpdateOrderRequest, Order>();
+
+var existing = db.Orders.Find(id)!;
+mapper.Patch(request, existing);   // only non-null fields overwrite existing
+db.SaveChanges();
+```
+
+No extra configuration needed — every type map automatically gets a patch delegate compiled at startup.
+
+---
+
+## Inline Validation
+
+Add post-mapping validation rules directly to a type map with `.Validate()`. All rules run after mapping completes; a `MappingValidationException` is thrown that contains **every** violation (not just the first):
+
+```csharp
+cfg.CreateMap<UserRequest, User>()
+   .Validate(d => d.Email, e => e.Contains("@"), "Email must be valid")
+   .Validate(d => d.Age,   a => a >= 18,          "Must be 18 or older")
+   .Validate(d => d.Name,  n => n.Length > 0,     "Name is required");
+```
+
+```csharp
+try
+{
+    var user = mapper.Map<UserRequest, User>(request);
+}
+catch (MappingValidationException ex)
+{
+    // ex.Errors — IReadOnlyList<string> with all violations
+    foreach (var err in ex.Errors) Console.WriteLine(err);
+}
+```
+
+Maps without `.Validate()` calls use the zero-overhead ctx-free path — no performance penalty for the common case.
+
+---
+
+## IQueryable Projection (ProjectTo)
+
+`ProjectTo<TSource, TDest>(config)` builds a pure `Expression<Func<TSource, TDest>>` from the registered type map and passes it directly to `IQueryable.Select()`. The expression is **never compiled** by EggMapper, so LINQ providers (EF Core, etc.) can translate it to SQL.
+
+```csharp
+cfg.CreateMap<Order, OrderDto>();
+
+// EF Core — translated to SQL SELECT
+var dtos = dbContext.Orders
+    .Where(o => o.IsActive)
+    .ProjectTo<Order, OrderDto>(config)
+    .ToListAsync();
+```
+
+Supports:
+- Flat DTOs (`MemberInitExpression`)
+- Records and parameterized constructors (`NewExpression` with member associations)
+- Nested registered maps (recursive projection)
+- Flattened properties (`AddressStreet` → `src.Address.Street`)
+- Custom `MapFrom` expressions inlined into the projection tree
+
+You can also get the raw expression for inspection or composition:
+
+```csharp
+Expression<Func<Order, OrderDto>> expr = config.BuildProjection<Order, OrderDto>();
+```

--- a/scripts/update-features.sh
+++ b/scripts/update-features.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# update-features.sh
+#
+# Appends new feature bullets to the README.md <!-- FEATURES_START/END --> block
+# and stubs new sections in docs/Advanced-Features.md for any `feat:` commits
+# that appeared since the last git tag.
+#
+# Usage (called from CI after tagging):
+#   bash scripts/update-features.sh
+#
+# Safe to run multiple times — skips entries already present.
+
+set -euo pipefail
+
+README="README.md"
+ADV_FEATURES="docs/Advanced-Features.md"
+
+# ── Find commits since last tag ────────────────────────────────────────────
+
+LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" HEAD^ 2>/dev/null || echo "")
+
+if [[ -z "$LAST_TAG" ]]; then
+  COMMIT_RANGE="HEAD"
+  echo "[update-features] No previous tag — scanning all commits"
+else
+  COMMIT_RANGE="${LAST_TAG}..HEAD"
+  echo "[update-features] Scanning commits since ${LAST_TAG}"
+fi
+
+# Collect feat: commit subjects (strip leading/trailing whitespace)
+FEAT_COMMITS=$(git log --pretty=format:"%s" ${COMMIT_RANGE} 2>/dev/null \
+  | grep -Ei "^feat(\([^)]+\))?:" \
+  | sed -E 's/^feat(\([^)]+\))?:[[:space:]]*//' \
+  || true)
+
+if [[ -z "$FEAT_COMMITS" ]]; then
+  echo "[update-features] No new feat: commits found — nothing to add."
+  exit 0
+fi
+
+# ── README features list ───────────────────────────────────────────────────
+
+updated_readme=false
+
+while IFS= read -r raw_feat; do
+  [[ -z "$raw_feat" ]] && continue
+
+  # Strip trailing parenthetical like " (Feature 8)" or " (#27)"
+  clean=$(echo "$raw_feat" | sed -E 's/ \(Feature [0-9]+\)//I; s/ \(#[0-9]+\)//')
+
+  # Skip if already present (case-insensitive substring match)
+  if grep -qi "$(echo "$clean" | cut -c1-40)" "$README"; then
+    echo "[update-features] Already in README: ${clean}"
+    continue
+  fi
+
+  bullet="- ✅ ${clean}"
+  echo "[update-features] Adding to README: ${bullet}"
+
+  # Insert the new bullet just before <!-- FEATURES_END -->
+  # Works on both GNU and BSD sed via a temp file
+  tmp=$(mktemp)
+  awk -v bullet="$bullet" '
+    /<!-- FEATURES_END -->/ { print bullet }
+    { print }
+  ' "$README" > "$tmp" && mv "$tmp" "$README"
+
+  updated_readme=true
+
+done <<< "$FEAT_COMMITS"
+
+$updated_readme && echo "[update-features] README updated." || true
+
+# ── docs/Advanced-Features.md stubs ───────────────────────────────────────
+
+updated_adv=false
+
+while IFS= read -r raw_feat; do
+  [[ -z "$raw_feat" ]] && continue
+
+  clean=$(echo "$raw_feat" | sed -E 's/ \(Feature [0-9]+\)//I; s/ \(#[0-9]+\)//')
+
+  # Use first ~5 words as a section heading fragment to check for duplicates
+  heading_fragment=$(echo "$clean" | awk '{print $1, $2, $3}')
+
+  if grep -qi "$heading_fragment" "$ADV_FEATURES" 2>/dev/null; then
+    echo "[update-features] Already in Advanced-Features.md: ${clean}"
+    continue
+  fi
+
+  echo "[update-features] Adding stub to Advanced-Features.md: ${clean}"
+
+  # Append a minimal stub section
+  cat >> "$ADV_FEATURES" <<STUB
+
+---
+
+## ${clean}
+
+<!-- TODO: expand this section with usage examples -->
+
+\`\`\`csharp
+// See the release notes and unit tests for usage examples.
+\`\`\`
+STUB
+
+  updated_adv=true
+
+done <<< "$FEAT_COMMITS"
+
+$updated_adv && echo "[update-features] docs/Advanced-Features.md updated." || true


### PR DESCRIPTION
## Summary

- **`scripts/update-features.sh`** — scans `feat:` commits since the last tag, strips prefixes/parentheticals, checks for duplicates, and inserts new `✅` bullets before `<!-- FEATURES_END -->` in `README.md`; also appends minimal stubs to `docs/Advanced-Features.md`
- **`publish.yml`** — new "Update feature docs" step runs the script before the version-bump commit, so every release automatically updates the features list and wiki
- **`README.md`** — added `<!-- FEATURES_START -->` / `<!-- FEATURES_END -->` markers + updated feature list to include Patch mapping, Inline validation, and ProjectTo (added in v1.8–v1.11)
- **`docs/Advanced-Features.md`** — full documentation sections for Features 5–8:
  - Record and constructor mapping
  - Patch / partial mapping
  - Inline validation (`.Validate()`)
  - IQueryable projection (`ProjectTo`)

## How it works going forward

Every time a `feat:` commit lands in a release:
1. CI calls `update-features.sh`
2. The commit subject (e.g. `feat: some new feature`) is cleaned and added as `- ✅ some new feature` in README
3. A stub section is appended to `docs/Advanced-Features.md` (wiki auto-syncs from `docs/` on push)
4. The update is committed back to `main` alongside the version bump — with `[skip ci]` to avoid loops

## Test plan

- [x] `scripts/update-features.sh` is idempotent (re-running skips duplicates)
- [x] README.md markers are correctly placed
- [x] docs/Advanced-Features.md has complete sections for all 8 features
- [x] publish.yml step added before version-bump commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)