### PR TITLE
fix: auto-generate README summary table from live benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,17 @@ public class MyService(IMapper mapper) { ... }
 
 All benchmarks run on BenchmarkDotNet with .NET 10. Ratio = time vs hand-written manual code (lower is better).
 
+<!-- SUMMARY_TABLE_START -->
 | Scenario | Manual | EggMapper | Mapster | AutoMapper | Mapperly* |
 |----------|--------|-----------|---------|------------|-----------|
-| **Flat (10 props)** | 14.5 ns | **29.5 ns** (2.0×) | 31.1 ns (2.1×) | 73.0 ns (5.0×) | 14.9 ns (1.0×) |
-| **Flattening** | 18.3 ns | **37.3 ns** (2.0×) | 38.8 ns (2.1×) | 92.5 ns (5.1×) | 26.2 ns (1.4×) |
-| **Deep (2 nested)** | 51.2 ns | **64.6 ns** (1.3×) | 72.3 ns (1.4×) | 111 ns (2.2×) | 52.0 ns (1.0×) |
-| **Complex (nest+coll)** | 62.4 ns | **88.8 ns** (1.4×) | 85.8 ns (1.4×) | 143 ns (2.3×) | 65.0 ns (1.0×) |
-| **Collection (100)** | 1.81 us | **1.95 us** (1.1×) | 1.85 us (1.0×) | 2.39 us (1.3×) | 1.85 us (1.0×) |
-| **Deep Coll (100)** | 5.18 us | **6.07 us** (1.2×) | 5.51 us (1.1×) | 7.58 us (1.5×) | 5.06 us (1.0×) |
-| **Large Coll (1000)** | 21.7 us | **27.7 us** (1.3×) | 24.1 us (1.1×) | 29.9 us (1.4×) | 24.8 us (1.1×) |
+| **Flat (10 props)** | 15.2 ns | **28.2 ns** (1.9×) | 28.4 ns (1.9×) | 83.5 ns (5.5×) | 15.0 ns (1.0×) |
+| **Flattening** | 18.7 ns | **31.4 ns** (1.7×) | 47.3 ns (2.5×) | 90.9 ns (4.9×) | 23.7 ns (1.3×) |
+| **Deep (2 nested)** | 54.3 ns | **68.0 ns** (1.3×) | 70.8 ns (1.3×) | 122 ns (2.3×) | 49.5 ns (0.9×) |
+| **Complex (nest+coll)** | 82.5 ns | **102 ns** (1.2×) | 97.4 ns (1.2×) | 161 ns (2.0×) | 77.9 ns (0.9×) |
+| **Collection (100)** | 1.80 us | **1.78 us** (1.0×) | 1.94 us (1.1×) | 2.56 us (1.4×) | 2.04 us (1.1×) |
+| **Deep Coll (100)** | 5.47 us | **5.97 us** (1.1×) | 6.04 us (1.1×) | 7.19 us (1.3×) | 5.67 us (1.0×) |
+| **Large Coll (1000)** | 17.3 us | **17.3 us** (1.0×) | 17.2 us (1.0×) | 20.8 us (1.2×) | 19.4 us (1.1×) |
+<!-- SUMMARY_TABLE_END -->
 
 **\*** *Mapperly is a compile-time source generator — it produces code equivalent to hand-written mapping. EggMapper is the fastest **runtime** mapper.*
 
@@ -234,7 +236,6 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 - ✅ Patch / partial mapping via `mapper.Patch<S,D>(src, dest)`
 - ✅ Inline validation rules via `.Validate()` (collects all failures before throwing)
 - ✅ IQueryable projection via `ProjectTo<S,D>(config)` for EF Core / LINQ providers
-- ✅ auto-update README features list and wiki docs on every release
 <!-- FEATURES_END -->
 
 ## Documentation

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -288,12 +288,3 @@ You can also get the raw expression for inspection or composition:
 Expression<Func<Order, OrderDto>> expr = config.BuildProjection<Order, OrderDto>();
 ```
 
----
-
-## auto-update README features list and wiki docs on every release
-
-<!-- TODO: expand this section with usage examples -->
-
-```csharp
-// See the release notes and unit tests for usage examples.
-```

--- a/scripts/update-features.sh
+++ b/scripts/update-features.sh
@@ -27,9 +27,11 @@ else
   echo "[update-features] Scanning commits since ${LAST_TAG}"
 fi
 
-# Collect feat: commit subjects (strip leading/trailing whitespace)
+# Collect feat: commit subjects (strip leading/trailing whitespace).
+# Exclude CI/tooling-only commits (docs/, scripts/, workflows/).
 FEAT_COMMITS=$(git log --pretty=format:"%s" ${COMMIT_RANGE} 2>/dev/null \
   | grep -Ei "^feat(\([^)]+\))?:" \
+  | grep -Eiv "(auto-update|readme features|wiki docs|update-features|benchmark)" \
   | sed -E 's/^feat(\([^)]+\))?:[[:space:]]*//' \
   || true)
 

--- a/scripts/update-readme-benchmarks.py
+++ b/scripts/update-readme-benchmarks.py
@@ -30,8 +30,10 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-START_MARKER = "<!-- BENCHMARK_RESULTS_START -->"
-END_MARKER   = "<!-- BENCHMARK_RESULTS_END -->"
+START_MARKER   = "<!-- BENCHMARK_RESULTS_START -->"
+END_MARKER     = "<!-- BENCHMARK_RESULTS_END -->"
+SUMMARY_START  = "<!-- SUMMARY_TABLE_START -->"
+SUMMARY_END    = "<!-- SUMMARY_TABLE_END -->"
 
 # Canonical order and short labels for the README summary
 BENCHMARK_ORDER: list[tuple[str, str]] = [
@@ -44,6 +46,27 @@ BENCHMARK_ORDER: list[tuple[str, str]] = [
     ("LargeCollectionBenchmark",  "⚫ Large Collection (1,000 items)"),
     ("StartupBenchmark",          "⚪ Startup / Config"),
 ]
+
+# Short scenario labels used in the summary table (omits Startup)
+SUMMARY_SCENARIOS: list[tuple[str, str]] = [
+    ("FlatMappingBenchmark",      "Flat (10 props)"),
+    ("FlatteningBenchmark",       "Flattening"),
+    ("DeepTypeBenchmark",         "Deep (2 nested)"),
+    ("ComplexTypeBenchmark",      "Complex (nest+coll)"),
+    ("CollectionBenchmark",       "Collection (100)"),
+    ("DeepCollectionBenchmark",   "Deep Coll (100)"),
+    ("LargeCollectionBenchmark",  "Large Coll (1000)"),
+]
+
+# Maps lowercase BDN method names → summary column keys
+_METHOD_KEYS: dict[str, str] = {
+    "manual":      "manual",
+    "eggmapper":   "egg",
+    "eggmap":      "egg",   # some benchmarks use the shorter alias
+    "automapper":  "am",
+    "mapster":     "ms",
+    "mapperlymap": "mly",
+}
 
 COLUMN_LEGEND = (
     "> **Column guide:** "
@@ -102,6 +125,90 @@ def _extract_table(filepath: str) -> str:
         return "\n".join(ln.rstrip() for ln in lines if ln.startswith("|"))
     except (OSError, UnicodeDecodeError) as exc:
         return f"*Error reading report: {exc}*"
+
+
+# ── Summary table builder ──────────────────────────────────────────────────
+
+def _parse_bdn_table(filepath: str) -> dict[str, tuple[str, str]]:
+    """
+    Parse a BDN markdown report and return {method_key: (mean_str, ratio_str)}.
+    Returns an empty dict on any error.
+    """
+    try:
+        with open(filepath, encoding="utf-8") as fh:
+            rows = [ln.rstrip() for ln in fh if ln.startswith("|")]
+    except OSError:
+        return {}
+
+    if len(rows) < 3:
+        return {}
+
+    # Header row: find column indices
+    header_cells = [c.strip() for c in rows[0].split("|")[1:-1]]
+    try:
+        mi = header_cells.index("Method")
+        vi = header_cells.index("Mean")
+        ri = header_cells.index("Ratio")
+    except ValueError:
+        return {}
+
+    results: dict[str, tuple[str, str]] = {}
+    for row in rows[2:]:  # skip header + separator
+        cells = [c.strip() for c in row.split("|")[1:-1]]
+        if len(cells) <= max(mi, vi, ri):
+            continue
+        key = _METHOD_KEYS.get(cells[mi].lower())
+        if key:
+            results[key] = (cells[vi], cells[ri])
+    return results
+
+
+def _fmt_cell(data: dict[str, tuple[str, str]], key: str) -> str:
+    """Format a summary cell as 'mean (ratio×)', rounding ratio to 1 dp."""
+    if key not in data:
+        return "—"
+    mean, ratio = data[key]
+    try:
+        r = round(float(ratio), 1)
+        return f"{mean} ({r}×)"
+    except ValueError:
+        return mean
+
+
+def build_summary_table(md_files: list[str]) -> str:
+    """
+    Build the compact summary table from BDN artifacts.
+    Returns the full markdown block (without the HTML markers).
+    """
+    lines = [
+        "| Scenario | Manual | EggMapper | Mapster | AutoMapper | Mapperly* |",
+        "|----------|--------|-----------|---------|------------|-----------|",
+    ]
+
+    for md_file in md_files:
+        label = None
+        for cls_name, short_label in SUMMARY_SCENARIOS:
+            if _match_class(cls_name, md_file):
+                label = short_label
+                break
+        if label is None:
+            continue  # skip Startup and unknown benchmarks
+
+        data = _parse_bdn_table(md_file)
+        if not data or "manual" not in data or "egg" not in data:
+            continue
+
+        manual_mean = data["manual"][0]
+        lines.append(
+            f"| **{label}** "
+            f"| {manual_mean} "
+            f"| **{_fmt_cell(data, 'egg')}** "
+            f"| {_fmt_cell(data, 'ms')} "
+            f"| {_fmt_cell(data, 'am')} "
+            f"| {_fmt_cell(data, 'mly')} |"
+        )
+
+    return "\n".join(lines)
 
 
 # ── Section builder ────────────────────────────────────────────────────────
@@ -171,22 +278,30 @@ def update_readme(artifacts_dir: str, readme_path: str) -> None:
     with open(readme_path, encoding="utf-8") as fh:
         content = fh.read()
 
-    new_section = build_performance_section(artifacts_dir)
+    md_files = _find_md_files(artifacts_dir)
+    new_content = content
 
-    if START_MARKER in content and END_MARKER in content:
-        # Precise marker-based replacement — always preferred.
+    # ── Detailed results section ─────────────────────────────────────────
+    new_section = build_performance_section(artifacts_dir)
+    if START_MARKER in new_content and END_MARKER in new_content:
         pattern = re.escape(START_MARKER) + r".*?" + re.escape(END_MARKER)
-        new_content = re.sub(pattern, new_section, content, flags=re.DOTALL)
+        new_content = re.sub(pattern, new_section, new_content, flags=re.DOTALL)
     else:
-        # Fallback: replace everything from the ## Performance heading until
-        # the next ## heading (or end of file).
         pattern = r"(## Performance\n)(.*?)(\n## |\Z)"
         new_content = re.sub(
             pattern,
             lambda m: m.group(1) + "\n" + new_section + "\n" + m.group(3),
-            content,
+            new_content,
             flags=re.DOTALL,
         )
+
+    # ── Summary table ────────────────────────────────────────────────────
+    if md_files and SUMMARY_START in new_content and SUMMARY_END in new_content:
+        table = build_summary_table(md_files)
+        if table:
+            replacement = f"{SUMMARY_START}\n{table}\n{SUMMARY_END}"
+            pattern = re.escape(SUMMARY_START) + r".*?" + re.escape(SUMMARY_END)
+            new_content = re.sub(pattern, replacement, new_content, flags=re.DOTALL)
 
     with open(readme_path, "w", encoding="utf-8") as fh:
         fh.write(new_content)


### PR DESCRIPTION
## Problem

The hardcoded summary table in the Performance section showed **stale, incorrect numbers** that didn't match the auto-updated detailed results below it. Examples from the last CI run:

| Scenario | Old summary table | Actual (live) |
|---|---|---|
| Large Coll (1000) – EggMapper | 27.7 us **(1.3×)** | 17.3 us **(1.0×)** — tied with manual! |
| Collection (100) – EggMapper | 1.95 us (1.1×) | 1.78 us **(1.0×)** — faster than manual! |
| Flat – EggMapper ratio | 2.0× | **1.85×** |
| Flat – Mapster | 31.1 ns | **28.4 ns** (was slower than EggMapper, now similar) |

## Fix

- Added `<!-- SUMMARY_TABLE_START -->` / `<!-- SUMMARY_TABLE_END -->` markers
- Extended `scripts/update-readme-benchmarks.py` with `_parse_bdn_table()` and `build_summary_table()` — parses Mean + Ratio from BDN artifacts and regenerates the table on every benchmark CI run
- Updated summary table to match current benchmark results
- Fixed two side-effects from the previous PR: spurious `auto-update` bullet in FEATURES list and a stray section in `docs/Advanced-Features.md`
- Tightened `update-features.sh` to filter out CI/tooling `feat:` commits

## After this PR

Every benchmark CI run will keep both the summary table and the detailed section in sync automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)