### PR TITLE
docs: Tier 5 documentation, migration guide, and diagnostic reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,35 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 - ✅ IQueryable projection via `ProjectTo<S,D>(config)` for EF Core / LINQ providers
 <!-- FEATURES_END -->
 
+## Mapping Tiers
+
+EggMapper supports three complementary mapping approaches. Choose based on your use case:
+
+| | **Runtime** (`EggMapper`) | **Tier 2** (`EggMapper.Generator`) | **Tier 3** (`EggMapper.ClassMapper`) |
+|---|---|---|---|
+| **API** | `MapperConfiguration` + `CreateMap` | `[MapTo(typeof(Dest))]` attribute | `[EggMapper]` partial class |
+| **Mapping errors detected** | Runtime | ✅ Build time | ✅ Build time |
+| **Reflection at map time** | None (expression trees) | ✅ None (generated code) | ✅ None (generated code) |
+| **Startup cost** | Compilation (once) | ✅ None | ✅ None |
+| **Custom logic** | Full (`ForMember`, hooks, etc.) | `AfterMap` hook | Full custom methods |
+| **Reverse mapping** | `ReverseMap()` | Separate `[MapTo]` annotation | Declare both `partial` methods |
+| **DI-friendly instance** | `IMapper` | N/A (extension methods) | ✅ `Instance` + constructors |
+| **Migration from AutoMapper** | ✅ Drop-in | Via EGG1003 suggestion | New API |
+| **Best for** | Complex/conditional mapping | Simple 1:1 copies | Custom logic + compile safety |
+
+See [Migration Guide](docs/Migration-Guide.md) to move from runtime to compile-time APIs.
+
+---
+
 ## Documentation
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](https://github.com/eggspot/EggMapper/wiki/Getting-Started) | Installation and your first mapping |
+| [Getting Started](https://github.com/eggspot/EggMapper/wiki/Getting-Started) | Installation and your first runtime mapping |
+| [Tier 2 Getting Started](docs/Tier2-Getting-Started.md) | Compile-time extension methods with `[MapTo]` |
+| [Tier 3 Getting Started](docs/Tier3-Getting-Started.md) | Compile-time partial mapper classes with `[EggMapper]` |
+| [Migration Guide](docs/Migration-Guide.md) | Moving from runtime to compile-time APIs |
+| [Diagnostic Reference](docs/diagnostics/) | All EGG diagnostic codes explained |
 | [Configuration](https://github.com/eggspot/EggMapper/wiki/Configuration) | `MapperConfiguration` options |
 | [Profiles](https://github.com/eggspot/EggMapper/wiki/Profiles) | Organising maps with `Profile` |
 | [Dependency Injection](https://github.com/eggspot/EggMapper/wiki/Dependency-Injection) | ASP.NET Core / DI integration |

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -1,0 +1,141 @@
+# Migration Guide: Runtime → Compile-Time Mapping
+
+EggMapper supports **three tiers** of mapping.  This guide walks through migrating from the runtime API (Tier 1 style) to the compile-time generators (Tier 2 and Tier 3).
+
+---
+
+## Tier overview
+
+| Tier | Package | API | When to use |
+|------|---------|-----|-------------|
+| Runtime | `EggMapper` | `MapperConfiguration` + `CreateMap` | Complex/conditional mapping, existing AutoMapper code |
+| Tier 2 | `EggMapper.Generator` | `[MapTo]` attribute | Simple 1:1 copies, want compile-time safety |
+| Tier 3 | `EggMapper.ClassMapper` | `[EggMapper]` partial class | Custom logic alongside generated code, DI, reverse mapping |
+
+You can mix all three tiers in the same project — there is no requirement to migrate everything at once.
+
+---
+
+## Migrating a simple `CreateMap` to `[MapTo]`
+
+### Before (runtime)
+
+```csharp
+var config = new MapperConfiguration(cfg =>
+{
+    cfg.CreateMap<Order, OrderDto>();
+});
+var mapper = config.CreateMapper();
+
+// Usage
+var dto = mapper.Map<OrderDto>(order);
+```
+
+### After (Tier 2 — compile-time extension method)
+
+```csharp
+// 1. Add [MapTo] to the source class
+[MapTo(typeof(OrderDto))]
+public class Order
+{
+    public int    Id    { get; set; }
+    public string Name  { get; set; } = "";
+}
+
+// 2. Use the generated extension
+var dto = order.ToOrderDto();
+```
+
+**What you gain:**
+- Mapping errors reported at **build time** (not runtime)
+- Zero startup cost — no `MapperConfiguration` needed
+- Zero reflection at call time
+
+---
+
+## Migrating a `CreateMap` with `ForMember` to `[EggMapper]`
+
+### Before (runtime with customization)
+
+```csharp
+cfg.CreateMap<Customer, CustomerDto>()
+   .ForMember(d => d.DisplayLabel,
+              o => o.MapFrom(s => $"{s.FirstName} {s.LastName}"));
+```
+
+### After (Tier 3 — partial class mapper)
+
+```csharp
+[EggMapper]
+public partial class CustomerMapper
+{
+    public partial CustomerDto Map(Customer source);
+
+    // Custom logic lives alongside the generated code
+    private string BuildDisplayLabel(Customer s)
+        => $"{s.FirstName} {s.LastName}";
+}
+```
+
+The generator maps all matching properties automatically and uses `BuildDisplayLabel(Customer)` automatically if `CustomerDto.DisplayLabel` is of type `string`.
+
+---
+
+## Migrating `ReverseMap`
+
+### Before (runtime)
+
+```csharp
+cfg.CreateMap<Order, OrderDto>().ReverseMap();
+```
+
+### After (Tier 3)
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);
+    public partial Order    Map(OrderDto source);
+}
+```
+
+---
+
+## Migrating `Profile` classes
+
+If you have a large `Profile` subclass, the Analyzer EGG1003 will flag each bare `CreateMap<S,D>()` call that has no customizations and suggest replacing it with `[MapTo]`.  Use the IDE quick-fix to apply the suggestion automatically.
+
+```
+// EGG1003 (Info): CreateMap<Order, OrderDto>() has no customizations.
+// Consider using [MapTo(typeof(OrderDto))] on Order with EggMapper.Generator
+// for compile-time type safety and zero-overhead mapping.
+```
+
+---
+
+## Keeping the runtime API
+
+Not everything needs to migrate.  Keep `CreateMap` + `ForMember` for:
+
+- Maps with `Condition`, `PreCondition`, `AfterMap` hooks
+- `ConstructUsing` / `ConvertUsing`
+- `MaxDepth` / `IncludeBase` / polymorphic inheritance
+- Dynamic map selection at runtime
+
+The runtime API is fully retained and will not be removed.
+
+---
+
+## Side-by-side checklist
+
+| Runtime feature | Tier 2 equivalent | Tier 3 equivalent |
+|----------------|------------------|------------------|
+| `CreateMap<S,D>()` | `[MapTo(typeof(D))]` on S | partial method in `[EggMapper]` class |
+| `ForMember` rename | `[MapProperty("Name")]` on source property | Custom converter method |
+| `Ignore()` | `[MapIgnore]` on source property | Omit from destination |
+| `ReverseMap()` | Add `[MapTo(typeof(S))]` on D | Add reverse partial method |
+| `AfterMap(…)` hook | `static partial void AfterMap(S,D)` | Custom method in mapper class |
+| Collection mapping | `ToOrderDtoList()` | Automatic via `List<TDst>` detection |
+| Nested type mapping | Declare `[MapTo]` on nested type too | Declare additional partial method |
+| DI singleton | N/A (static extension) | `MyMapper.Instance` + constructor injection |

--- a/docs/Tier2-Getting-Started.md
+++ b/docs/Tier2-Getting-Started.md
@@ -1,0 +1,132 @@
+# Getting Started: Tier 2 — Compile-Time Extension Methods (`[MapTo]`)
+
+`EggMapper.Generator` generates **zero-reflection, zero-allocation extension methods** at build time from a single `[MapTo]` attribute.  No `MapperConfiguration`, no runtime delegates — the mapping code is emitted directly into your binary.
+
+---
+
+## Installation
+
+```bash
+dotnet add package EggMapper.Generator
+```
+
+> The generator package automatically injects the `[MapTo]`, `[MapProperty]`, and `[MapIgnore]` attributes into your compilation — no separate abstractions package needed.
+
+---
+
+## Basic Usage
+
+### 1 — Annotate the source class
+
+```csharp
+using EggMapper;
+
+[MapTo(typeof(OrderDto))]
+public class Order
+{
+    public int    Id           { get; set; }
+    public string CustomerName { get; set; } = "";
+    public decimal Total       { get; set; }
+}
+
+public class OrderDto
+{
+    public int    Id           { get; set; }
+    public string CustomerName { get; set; } = "";
+    public decimal Total       { get; set; }
+}
+```
+
+### 2 — Use the generated extension method
+
+```csharp
+var order = new Order { Id = 1, CustomerName = "Alice", Total = 99.99m };
+OrderDto dto = order.ToOrderDto();               // generated extension method
+List<OrderDto> dtos = orders.ToOrderDtoList();   // generated list method
+```
+
+No mapper instance, no DI registration, no startup cost.
+
+---
+
+## Multiple Destinations
+
+Apply `[MapTo]` multiple times to map a single source to several destinations:
+
+```csharp
+[MapTo(typeof(OrderDto))]
+[MapTo(typeof(OrderSummary))]
+public class Order { ... }
+```
+
+Generates `ToOrderDto()`, `ToOrderDtoList()`, `ToOrderSummary()`, and `ToOrderSummaryList()`.
+
+---
+
+## Renaming Properties (`[MapProperty]`)
+
+```csharp
+[MapTo(typeof(CustomerDto))]
+public class Customer
+{
+    public int    Id   { get; set; }
+
+    [MapProperty("FullName")]   // maps Customer.Name → CustomerDto.FullName
+    public string Name { get; set; } = "";
+}
+```
+
+---
+
+## Ignoring Properties (`[MapIgnore]`)
+
+```csharp
+[MapTo(typeof(CustomerDto))]
+public class Customer
+{
+    public int    Id       { get; set; }
+    public string Name     { get; set; } = "";
+
+    [MapIgnore]
+    public string Password { get; set; } = "";  // not copied to CustomerDto
+}
+```
+
+---
+
+## Post-Map Hook (`AfterMap`)
+
+Declare a partial static method to run custom logic after the generated initializer:
+
+```csharp
+// In a separate file (user-authored):
+public static partial class OrderToOrderDtoExtensions
+{
+    static partial void AfterMap(Order source, OrderDto dest)
+    {
+        dest.DisplayName = $"#{source.Id} — {source.CustomerName}";
+    }
+}
+```
+
+The generated `ToOrderDto()` calls `AfterMap(source, dest)` after building the object.
+
+---
+
+## Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| EGG2001 | Error | A destination property has no matching source member |
+| EGG2002 | Info | An implicit type conversion was applied |
+
+---
+
+## When to Use Tier 2 vs Runtime EggMapper
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Simple 1:1 property copying, no custom logic | **Tier 2** — zero overhead, compile-time safety |
+| Complex conditional mapping, `BeforeMap`/`AfterMap` hooks | **Runtime EggMapper** |
+| Need `ForMember`, `ConvertUsing`, `MaxDepth` | **Runtime EggMapper** |
+| Want type errors at build time, not runtime | **Tier 2** |

--- a/docs/Tier3-Getting-Started.md
+++ b/docs/Tier3-Getting-Started.md
@@ -1,0 +1,163 @@
+# Getting Started: Tier 3 — Mapper Class Generation (`[EggMapper]`)
+
+`EggMapper.ClassMapper` generates implementations for **partial mapping methods** you declare in a class.  You get full IDE auto-complete, type-checked mapping, and the ability to add custom logic alongside the generated code — all at zero runtime cost.
+
+---
+
+## Installation
+
+```bash
+dotnet add package EggMapper.ClassMapper
+```
+
+---
+
+## Basic Usage
+
+### 1 — Declare a partial mapper class
+
+```csharp
+using EggMapper;
+
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);
+}
+```
+
+### 2 — The generator produces the implementation
+
+```csharp
+// Auto-generated (OrderMapper.g.cs):
+public partial class OrderMapper
+{
+    public static OrderMapper Instance { get; } = new OrderMapper();
+
+    public partial OrderDto Map(Order source)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        return new OrderDto
+        {
+            Id           = source.Id,
+            CustomerName = source.CustomerName,
+            Total        = source.Total,
+        };
+    }
+}
+```
+
+### 3 — Use the mapper
+
+```csharp
+// Option A: static singleton
+OrderDto dto = OrderMapper.Instance.Map(order);
+
+// Option B: DI registration
+services.AddSingleton<OrderMapper>();
+// ...
+OrderDto dto = mapper.Map(order);
+```
+
+---
+
+## Reverse Mapping
+
+Declare both directions and the generator implements both:
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);
+    public partial Order    Map(OrderDto source);   // reverse
+}
+```
+
+---
+
+## Nested Type Mapping
+
+Declare a method for each nested type — the generator chains them automatically:
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto    Map(Order source);
+    public partial AddressDto  Map(Address source);  // auto-used for Order.Address
+}
+```
+
+The generated `Map(Order)` emits `Address = Map(source.Address)`.
+
+---
+
+## Collection Mapping
+
+If a destination property is `List<TDst>` and source is a list-like type, and you have a partial method that maps `TSrc → TDst`:
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);       // Order.Lines → OrderDto.Lines
+    public partial LineDto  Map(Line source);        // element mapper
+}
+// Generated: Lines = source.Lines?.Select(Map).ToList() ?? new List<LineDto>()
+```
+
+---
+
+## Custom Converter Methods
+
+Add non-partial methods to the mapper class — the generator detects them by signature and uses them automatically:
+
+```csharp
+[EggMapper]
+public partial class PersonMapper
+{
+    public partial PersonDto Map(Person source);
+
+    // Converter: DateTime → string — used automatically for Birthday property
+    private string FormatDate(DateTime d) => d.ToString("yyyy-MM-dd");
+}
+```
+
+---
+
+## Enum Mapping
+
+Enum-to-enum properties are mapped with an explicit cast.  If underlying types differ, EGG3003 (Info) is reported.
+
+```csharp
+[EggMapper]
+public partial class StatusMapper
+{
+    public partial StatusDto Map(Status source);
+}
+// Generated: Kind = (StatusDtoKind)source.Kind,
+```
+
+---
+
+## Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| EGG3001 | Warning | A writable destination property has no matching source — left at default |
+| EGG3002 | Warning | `[EggMapper]` class has no partial mapping methods |
+| EGG3003 | Info | Enum-to-enum cast where underlying types differ |
+
+---
+
+## When to Use Tier 3 vs Tier 2
+
+| Feature | Tier 2 `[MapTo]` | Tier 3 `[EggMapper]` |
+|---------|-----------------|---------------------|
+| Simple property copy | ✅ | ✅ |
+| Reverse mapping | ❌ | ✅ |
+| Multiple destinations from one source | ✅ | ✅ |
+| Custom converter logic alongside generated | Limited (AfterMap hook) | ✅ full methods |
+| DI-friendly mapper instance | ❌ (static extension) | ✅ (Instance + ctor) |
+| Property rename/ignore | ✅ `[MapProperty]`/`[MapIgnore]` | via converter method |

--- a/docs/diagnostics/EGG1002.md
+++ b/docs/diagnostics/EGG1002.md
@@ -1,0 +1,50 @@
+# EGG1002 — MapperConfiguration missing AssertConfigurationIsValid
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Warning |
+| **Package** | `EggMapper.Analyzers` |
+| **Category** | EggMapper |
+
+## Description
+
+`MapperConfiguration` is constructed but `AssertConfigurationIsValid()` is never called anywhere in the compilation.  Without this call, mapping mismatches (e.g., a destination property that has no source) are silent until the first `Map<>()` call at runtime.
+
+## Example (triggers warning)
+
+```csharp
+var config = new MapperConfiguration(cfg =>
+{
+    cfg.CreateMap<Order, OrderDto>();
+});
+// Missing: config.AssertConfigurationIsValid();
+```
+
+## How to fix
+
+Call `AssertConfigurationIsValid()` at application startup — before serving any requests:
+
+```csharp
+var config = new MapperConfiguration(cfg =>
+{
+    cfg.CreateMap<Order, OrderDto>();
+});
+config.AssertConfigurationIsValid();   // ← throws if any map is misconfigured
+var mapper = config.CreateMapper();
+```
+
+The call can be in any method in the compilation — it does not need to be immediately after the constructor.
+
+## How to suppress
+
+```csharp
+#pragma warning disable EGG1002
+var config = new MapperConfiguration(...);
+#pragma warning restore EGG1002
+```
+
+Or in `.editorconfig`:
+
+```ini
+dotnet_diagnostic.EGG1002.severity = none
+```

--- a/docs/diagnostics/EGG1003.md
+++ b/docs/diagnostics/EGG1003.md
@@ -1,0 +1,57 @@
+# EGG1003 — Consider compile-time mapping with `[MapTo]`
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Info |
+| **Package** | `EggMapper.Analyzers` |
+| **Category** | EggMapper |
+
+## Description
+
+A `CreateMap<TSource, TDestination>()` call has no customization chains (no `ForMember`, `BeforeMap`, `AfterMap`, etc.).  Simple maps like this can be replaced with the `[MapTo(typeof(TDestination))]` attribute and `EggMapper.Generator`, gaining compile-time type checking and zero-overhead mapping.
+
+`ReverseMap()` alone is **not** considered a customization — the diagnostic still fires.
+
+## Example (triggers info)
+
+```csharp
+class MyProfile : Profile
+{
+    public MyProfile()
+    {
+        CreateMap<Order, OrderDto>();              // EGG1003
+        CreateMap<Customer, CustomerDto>()
+            .ReverseMap();                         // EGG1003 (ReverseMap alone is not a customization)
+        CreateMap<Line, LineDto>()
+            .ForMember(d => d.Label, o => ...);   // no diagnostic — has customization
+    }
+}
+```
+
+## How to fix
+
+Install `EggMapper.Generator` and annotate the source class:
+
+```csharp
+[MapTo(typeof(OrderDto))]
+public class Order { ... }
+
+// Usage:
+var dto = order.ToOrderDto();
+```
+
+See [Tier 2 Getting Started](../Tier2-Getting-Started.md) for full details.
+
+## How to suppress
+
+```csharp
+#pragma warning disable EGG1003
+CreateMap<Order, OrderDto>();
+#pragma warning restore EGG1003
+```
+
+Or in `.editorconfig`:
+
+```ini
+dotnet_diagnostic.EGG1003.severity = none
+```

--- a/docs/diagnostics/EGG2001.md
+++ b/docs/diagnostics/EGG2001.md
@@ -1,0 +1,54 @@
+# EGG2001 — Unmapped destination property (Generator)
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Package** | `EggMapper.Generator` |
+| **Category** | EggMapper |
+
+## Description
+
+A writable property on the destination type has no matching source property and no explicit mapping override.  No extension method source is generated when this error is present.
+
+## Example (triggers error)
+
+```csharp
+[MapTo(typeof(OrderDto))]
+public class Order
+{
+    public int Id { get; set; }
+    // Missing: Label property
+}
+
+public class OrderDto
+{
+    public int    Id    { get; set; }
+    public string Label { get; set; } = "";   // ← EGG2001: no source for 'Label'
+}
+```
+
+## How to fix
+
+**Option A** — Add the matching property to the source:
+
+```csharp
+public class Order
+{
+    public int    Id    { get; set; }
+    public string Label { get; set; } = "";
+}
+```
+
+**Option B** — Ignore the destination property using `[MapIgnore]` on the source (requires a corresponding source property):
+
+Not applicable when the property only exists on the destination.  Use the `AfterMap` hook instead:
+
+```csharp
+public static partial class OrderToOrderDtoExtensions
+{
+    static partial void AfterMap(Order source, OrderDto dest)
+    {
+        dest.Label = "default";
+    }
+}
+```

--- a/docs/diagnostics/EGG2002.md
+++ b/docs/diagnostics/EGG2002.md
@@ -1,0 +1,38 @@
+# EGG2002 — Implicit type conversion applied (Generator)
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Warning |
+| **Package** | `EggMapper.Generator` |
+| **Category** | EggMapper |
+
+## Description
+
+A source property and destination property share the same name but have different types.  The generator applied an implicit or explicit conversion (e.g., `int` → `long`, enum cast).  The warning surfaces so you are aware a conversion is happening rather than a direct copy.
+
+## Example (triggers warning)
+
+```csharp
+[MapTo(typeof(OrderDto))]
+public class Order
+{
+    public int Status { get; set; }   // int
+}
+
+public class OrderDto
+{
+    public long Status { get; set; }  // long — EGG2002: implicit int→long
+}
+```
+
+## How to fix
+
+If the conversion is intentional, suppress the warning.  If it is a mistake, align the property types.
+
+## How to suppress
+
+```csharp
+#pragma warning disable EGG2002
+// ... your [MapTo]-annotated class
+#pragma warning restore EGG2002
+```

--- a/docs/diagnostics/EGG3001.md
+++ b/docs/diagnostics/EGG3001.md
@@ -1,0 +1,56 @@
+# EGG3001 — Unmapped destination property (ClassMapper)
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Warning |
+| **Package** | `EggMapper.ClassMapper` |
+| **Category** | EggMapper |
+
+## Description
+
+A writable property on the destination type has no matching source property, no custom converter method, and no other partial method that maps the source type to the destination type.  The property will be left at its default value in the generated implementation.
+
+## Example (triggers warning)
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);   // EGG3001: OrderDto.Label has no source
+}
+
+public class Order   { public int Id { get; set; } }
+public class OrderDto{ public int Id { get; set; } public string Label { get; set; } = ""; }
+```
+
+## How to fix
+
+**Option A** — Add a matching property to the source type:
+
+```csharp
+public class Order { public int Id { get; set; } public string Label { get; set; } = ""; }
+```
+
+**Option B** — Add a custom converter method that provides the value:
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);
+
+    // Called for Order → string conversions (no source match needed)
+    private string BuildLabel(Order source) => $"Order #{source.Id}";
+}
+```
+
+> Note: Converter methods are matched by parameter/return type, not by property name.
+
+**Option C** — Post-process in a converter or subclass if both approaches are impractical.
+
+## How to suppress
+
+```ini
+# .editorconfig
+dotnet_diagnostic.EGG3001.severity = none
+```

--- a/docs/diagnostics/EGG3002.md
+++ b/docs/diagnostics/EGG3002.md
@@ -1,0 +1,37 @@
+# EGG3002 — No mapping methods declared (ClassMapper)
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Warning |
+| **Package** | `EggMapper.ClassMapper` |
+| **Category** | EggMapper |
+
+## Description
+
+A class is annotated with `[EggMapper]` but does not declare any `partial` mapping methods (methods with a single parameter and a non-void return type).  No source is generated for the class.
+
+## Example (triggers warning)
+
+```csharp
+[EggMapper]
+public partial class EmptyMapper   // EGG3002: no partial mapping methods
+{
+}
+```
+
+## How to fix
+
+Declare at least one `partial` mapping method:
+
+```csharp
+[EggMapper]
+public partial class OrderMapper
+{
+    public partial OrderDto Map(Order source);
+}
+```
+
+Requirements for a valid mapping method:
+- Declared `partial` (no body in the user file)
+- Exactly one parameter (the source object)
+- Non-void return type (the destination type)

--- a/docs/diagnostics/EGG3003.md
+++ b/docs/diagnostics/EGG3003.md
@@ -1,0 +1,46 @@
+# EGG3003 — Enum underlying type mismatch (ClassMapper)
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Info |
+| **Package** | `EggMapper.ClassMapper` |
+| **Category** | EggMapper |
+
+## Description
+
+Two enum types are being mapped and their underlying types differ (e.g., `byte` vs `int`).  An explicit cast is still generated, but numerical values may not correspond between the two enums — e.g., `StatusKind.Active = 0` might become `StatusDtoKind.Inactive = 0`.
+
+## Example (triggers info)
+
+```csharp
+public enum SourceStatus : byte  { Active = 1, Inactive = 2 }
+public enum DestStatus   : int   { Inactive = 0, Active = 1 }   // different ordinals!
+```
+
+When `SourceStatus.Active` (= `1`) is cast to `DestStatus`, you get `DestStatus.Active` (= `1`).  This might be correct, but EGG3003 flags it so you can verify intentionality.
+
+## How to fix
+
+If the mapping is correct, suppress the diagnostic.  If not, add a custom converter method:
+
+```csharp
+[EggMapper]
+public partial class StatusMapper
+{
+    public partial StatusDto Map(Status source);
+
+    private DestStatus ConvertStatus(SourceStatus s) => s switch
+    {
+        SourceStatus.Active   => DestStatus.Active,
+        SourceStatus.Inactive => DestStatus.Inactive,
+        _                     => throw new ArgumentOutOfRangeException(nameof(s))
+    };
+}
+```
+
+## How to suppress
+
+```ini
+# .editorconfig
+dotnet_diagnostic.EGG3003.severity = none
+```


### PR DESCRIPTION
## Summary

- **Tiered feature matrix** added to README comparing Runtime / Tier 2 / Tier 3 side-by-side
- Updated Documentation table in README with links to all new guides

### New docs

| File | Description |
|------|-------------|
| `docs/Tier2-Getting-Started.md` | `[MapTo]` extension method generator — installation, usage, rename/ignore, AfterMap hook |
| `docs/Tier3-Getting-Started.md` | `[EggMapper]` partial class mapper — reverse mapping, nested, collections, custom converters, enum mapping |
| `docs/Migration-Guide.md` | Side-by-side migration from runtime `CreateMap` to Tier 2/3, including `ForMember`, `ReverseMap`, and Profile migration |
| `docs/diagnostics/EGG1002.md` | Analyzer: missing AssertConfigurationIsValid |
| `docs/diagnostics/EGG1003.md` | Analyzer: suggest compile-time mapping |
| `docs/diagnostics/EGG2001.md` | Generator: unmapped destination property (error) |
| `docs/diagnostics/EGG2002.md` | Generator: implicit type conversion (warning) |
| `docs/diagnostics/EGG3001.md` | ClassMapper: unmapped destination property (warning) |
| `docs/diagnostics/EGG3002.md` | ClassMapper: no partial methods declared (warning) |
| `docs/diagnostics/EGG3003.md` | ClassMapper: enum underlying type mismatch (info) |

## Test plan

- [x] All Markdown files render correctly (checked locally)
- [x] README links point to correct relative paths

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)