### PR TITLE
feat: flattening support in [MapTo] generator (issue #33)

### DIFF
--- a/src/EggMapper.Generator.Tests/MapToGeneratorTests.cs
+++ b/src/EggMapper.Generator.Tests/MapToGeneratorTests.cs
@@ -293,5 +293,169 @@ public class OrderDto
             var generated = result.GetSource("OrderToOrderDtoExtensions");
             generated.Should().NotContain("namespace ");
         }
+
+        // ── Flattening ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Flattening_BasicCase_GeneratesNullSafeExpression()
+        {
+            const string source = @"
+using EggMapper;
+
+namespace MyApp
+{
+    [MapTo(typeof(OrderDto))]
+    public class Order
+    {
+        public int Id { get; set; }
+        public Address ShippingAddress { get; set; }
+    }
+
+    public class Address
+    {
+        public string Street { get; set; } = """";
+        public string City { get; set; } = """";
+    }
+
+    public class OrderDto
+    {
+        public int Id { get; set; }
+        public string ShippingAddressStreet { get; set; } = """";
+        public string ShippingAddressCity { get; set; } = """";
+    }
+}";
+
+            var result = GeneratorTestHelper.Run(source);
+
+            result.Diagnostics.Should().BeEmpty();
+            var generated = result.GetSource("OrderToOrderDtoExtensions");
+            generated.Should().NotBeNull();
+            generated.Should().Contain("ShippingAddressStreet = source.ShippingAddress != null ? source.ShippingAddress.Street : default");
+            generated.Should().Contain("ShippingAddressCity = source.ShippingAddress != null ? source.ShippingAddress.City : default");
+        }
+
+        [Fact]
+        public void Flattening_ValueTypeNavProp_NoNullGuard()
+        {
+            const string source = @"
+using EggMapper;
+
+namespace MyApp
+{
+    [MapTo(typeof(PointDto))]
+    public class Shape
+    {
+        public Point Center { get; set; }
+    }
+
+    public struct Point
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+    }
+
+    public class PointDto
+    {
+        public int CenterX { get; set; }
+        public int CenterY { get; set; }
+    }
+}";
+
+            var result = GeneratorTestHelper.Run(source);
+
+            result.Diagnostics.Should().BeEmpty();
+            var generated = result.GetSource("ShapeToPointDtoExtensions");
+            generated.Should().Contain("CenterX = source.Center.X");
+            generated.Should().Contain("CenterY = source.Center.Y");
+            generated.Should().NotContain("Center != null");
+        }
+
+        [Fact]
+        public void Flattening_NoEgg2001_ForFlattenedProperties()
+        {
+            const string source = @"
+using EggMapper;
+
+namespace MyApp
+{
+    [MapTo(typeof(Dto))]
+    public class Source
+    {
+        public Address Address { get; set; }
+    }
+
+    public class Address { public string Street { get; set; } = """"; }
+
+    public class Dto
+    {
+        public string AddressStreet { get; set; } = """";
+    }
+}";
+
+            var result = GeneratorTestHelper.Run(source);
+
+            result.Diagnostics.Should().NotContain(d => d.Id == "EGG2001");
+        }
+
+        [Fact]
+        public void Flattening_MapIgnoreOnNavProp_SuppressesFlattening()
+        {
+            const string source = @"
+using EggMapper;
+
+namespace MyApp
+{
+    [MapTo(typeof(Dto))]
+    public class Source
+    {
+        [MapIgnore]
+        public Address Address { get; set; }
+        public string Other { get; set; } = """";
+    }
+
+    public class Address { public string Street { get; set; } = """"; }
+
+    public class Dto
+    {
+        public string Other { get; set; } = """";
+        public string AddressStreet { get; set; } = """";
+    }
+}";
+
+            var result = GeneratorTestHelper.Run(source);
+
+            // EGG2001 fires for AddressStreet because Address is ignored
+            result.Diagnostics.Should().Contain(d => d.Id == "EGG2001" && d.GetMessage().Contains("AddressStreet"));
+        }
+
+        [Fact]
+        public void Flattening_MapPropertyOnNavProp_PreventsFlattening()
+        {
+            const string source = @"
+using EggMapper;
+
+namespace MyApp
+{
+    [MapTo(typeof(Dto))]
+    public class Source
+    {
+        [MapProperty(""DeliveryAddress"")]
+        public Address ShippingAddress { get; set; }
+    }
+
+    public class Address { public string Street { get; set; } = """"; }
+
+    public class Dto
+    {
+        public Address DeliveryAddress { get; set; }
+        public string ShippingAddressStreet { get; set; } = """";
+    }
+}";
+
+            var result = GeneratorTestHelper.Run(source);
+
+            // ShippingAddress is redirected to DeliveryAddress, so ShippingAddressStreet can't be flattened
+            result.Diagnostics.Should().Contain(d => d.Id == "EGG2001" && d.GetMessage().Contains("ShippingAddressStreet"));
+        }
     }
 }

--- a/src/EggMapper.Generator/MapToGenerator.cs
+++ b/src/EggMapper.Generator/MapToGenerator.cs
@@ -108,6 +108,7 @@ namespace EggMapper.Generator
             // Build lookup: destination name → source property (after [MapProperty] / [MapIgnore])
             var assignments = new List<(string destPropName, string srcExpression, bool needsCast, IPropertySymbol destProp, IPropertySymbol? srcProp)>();
             var ignoredSrcNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var redirectedSrcNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Index source props by their effective destination name
             var srcByDestName = new Dictionary<string, IPropertySymbol>(StringComparer.OrdinalIgnoreCase);
@@ -122,10 +123,23 @@ namespace EggMapper.Generator
                 string effectiveName = sp.Name;
                 var mapProp = GetMapPropertyAttribute(sp, MapPropertyFqn);
                 if (mapProp is not null)
+                {
                     effectiveName = mapProp;
+                    redirectedSrcNames.Add(sp.Name); // [MapProperty] redirects this prop — exclude from flattening
+                }
 
                 // Last one wins if multiple source props redirect to same dest name
                 srcByDestName[effectiveName] = sp;
+            }
+
+            // Source props eligible as navigation properties for flattening:
+            // not ignored, not [MapProperty]-redirected to a specific dest name
+            var navCandidates = new List<IPropertySymbol>();
+            foreach (var sp in srcProps)
+            {
+                if (ignoredSrcNames.Contains(sp.Name)) continue;
+                if (redirectedSrcNames.Contains(sp.Name)) continue;
+                navCandidates.Add(sp);
             }
 
             // Collect destination writable properties
@@ -135,7 +149,15 @@ namespace EggMapper.Generator
             {
                 if (!srcByDestName.TryGetValue(dp.Name, out var sp))
                 {
-                    // No matching source property
+                    // Try flattened path: e.g. dest "AddressStreet" ← source.Address.Street
+                    var flat = TryFlattenMatch(dp, navCandidates, compilation);
+                    if (flat is not null)
+                    {
+                        assignments.Add((dp.Name, flat.Value.srcExpr, flat.Value.needsCast, dp, null));
+                        continue;
+                    }
+
+                    // No direct match and no flattened path → EGG2001
                     diagnostics.Add(Diagnostic.Create(
                         Diagnostics.UnmappedDestinationProperty,
                         Location.None,
@@ -240,6 +262,81 @@ namespace EggMapper.Generator
         }
 
         // ── Helpers ──────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Tries to resolve a destination property via flattening convention:
+        /// <c>destProp.Name = "AddressStreet"</c> → <c>source.Address.Street</c>.
+        /// Returns the source expression (with null guard for reference-type nav props)
+        /// or null if no flattened path exists.
+        /// </summary>
+        private static (string srcExpr, bool needsCast)? TryFlattenMatch(
+            IPropertySymbol destProp,
+            IReadOnlyList<IPropertySymbol> navCandidates,
+            Compilation compilation)
+        {
+            string destName = destProp.Name;
+
+            foreach (var nav in navCandidates)
+            {
+                if (!destName.StartsWith(nav.Name, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string remainder = destName.Substring(nav.Name.Length);
+                if (string.IsNullOrEmpty(remainder))
+                    continue; // exact name match — handled by direct lookup
+
+                if (nav.Type is not INamedTypeSymbol navType)
+                    continue;
+
+                var nested = FindReadableProperty(navType, remainder);
+                if (nested == null)
+                    continue;
+
+                // Check type compatibility between nested prop and dest prop
+                var conv = compilation.ClassifyConversion(nested.Type, destProp.Type);
+                if (!conv.IsIdentity && !conv.IsImplicit && !conv.IsExplicit)
+                    continue; // incompatible types — try next candidate
+
+                bool needsCast = !conv.IsIdentity && !conv.IsImplicit;
+                string castPrefix = needsCast
+                    ? $"({destProp.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})"
+                    : "";
+
+                // Value-type nav props can never be null — no null guard needed
+                bool navCanBeNull = !nav.Type.IsValueType ||
+                    (navType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T);
+
+                string srcExpr = navCanBeNull
+                    ? $"source.{nav.Name} != null ? {castPrefix}source.{nav.Name}.{nested.Name} : default"
+                    : $"{castPrefix}source.{nav.Name}.{nested.Name}";
+
+                return (srcExpr, needsCast);
+            }
+
+            return null;
+        }
+
+        /// <summary>Case-insensitive search for a readable public instance property on <paramref name="type"/>.</summary>
+        private static IPropertySymbol? FindReadableProperty(INamedTypeSymbol type, string name)
+        {
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var member in t.GetMembers())
+                {
+                    if (member is IPropertySymbol prop
+                        && !prop.IsStatic
+                        && !prop.IsIndexer
+                        && prop.GetMethod is not null
+                        && prop.DeclaredAccessibility == Accessibility.Public
+                        && string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return prop;
+                    }
+                }
+                if (t.SpecialType == SpecialType.System_Object) break;
+            }
+            return null;
+        }
 
         private static IReadOnlyList<IPropertySymbol> GetReadableProperties(INamedTypeSymbol type)
         {


### PR DESCRIPTION
## Summary
- Destination properties matching a flattened source path (e.g. `AddressStreet` → `source.Address.Street`) are now auto-resolved by the `[MapTo]` generator
- Null-safe ternary emitted for reference-type nav props; direct access for value-type (struct) nav props
- `[MapIgnore]` on a nav property suppresses all its flattened derivations; `[MapProperty]`-redirected props are excluded from flattening
- EGG2001 is not raised for properties satisfied by flattening

## Test plan
- [x] `Flattening_BasicCase_GeneratesNullSafeExpression`
- [x] `Flattening_ValueTypeNavProp_NoNullGuard`
- [x] `Flattening_NoEgg2001_ForFlattenedProperties`
- [x] `Flattening_MapIgnoreOnNavProp_SuppressesFlattening`
- [x] `Flattening_MapPropertyOnNavProp_PreventsFlattening`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)