### PR TITLE
perf: three-round review — correctness + perf fixes

### DIFF
--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -454,7 +454,7 @@ internal static class ExpressionBuilder
         if (ReflectionHelper.IsCollectionType(srcType) && ReflectionHelper.IsCollectionType(destType))
         {
             if (allTypeMaps == null) return null;
-            return TryBuildCtxFreeCollectionAssign(srcParam, dVar, srcProp, destProp, allTypeMaps);
+            return TryBuildCtxFreeCollectionAssign(srcParam, dVar, srcProp, destProp, allTypeMaps, globalConverters);
         }
         if (ReflectionHelper.IsCollectionType(srcType) || ReflectionHelper.IsCollectionType(destType))
             return null;
@@ -521,7 +521,7 @@ internal static class ExpressionBuilder
         // ── Nested reference type — try to inline child map ──────────────────
         if (!srcType.IsValueType && allTypeMaps != null)
         {
-            var nested = TryBuildCtxFreeNestedAssign(srcParam, dVar, srcProp, destProp, allTypeMaps);
+            var nested = TryBuildCtxFreeNestedAssign(srcParam, dVar, srcProp, destProp, allTypeMaps, globalConverters);
             if (nested != null) return nested;
         }
 
@@ -602,7 +602,8 @@ internal static class ExpressionBuilder
         ParameterExpression dVar,
         PropertyInfo srcProp,
         PropertyInfo destProp,
-        Dictionary<TypePair, TypeMap> allTypeMaps)
+        Dictionary<TypePair, TypeMap> allTypeMaps,
+        Dictionary<TypePair, Delegate>? globalConverters = null)
     {
         var srcType = srcProp.PropertyType;
         var destType = destProp.PropertyType;
@@ -614,10 +615,13 @@ internal static class ExpressionBuilder
         // Only inline simple child maps
         if (childTypeMap.BeforeMapAction != null || childTypeMap.AfterMapAction != null) return null;
         if (childTypeMap.MaxDepth > 0 || childTypeMap.BaseMapTypePair.HasValue) return null;
-        if (childTypeMap.PropertyMaps.Any(pm =>
-            pm.Condition != null || pm.FullCondition != null || pm.PreCondition != null
-            || pm.HasNullSubstitute || pm.CustomResolver != null))
-            return null;
+        for (int i = 0; i < childTypeMap.PropertyMaps.Count; i++)
+        {
+            var pm = childTypeMap.PropertyMaps[i];
+            if (pm.Condition != null || pm.FullCondition != null || pm.PreCondition != null
+                || pm.HasNullSubstitute || pm.CustomResolver != null)
+                return null;
+        }
 
         // Self-referencing guard
         if (srcType == destType) return null;
@@ -676,7 +680,7 @@ internal static class ExpressionBuilder
             {
                 childSrcDetails.ReadableByName.TryGetValue(pm.SourceMemberName, out var cSrcProp);
                 if (cSrcProp == null) continue;
-                var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, pm.DestinationProperty);
+                var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, pm.DestinationProperty, globalConverters);
                 if (assign == null) return null;
                 innerStmts.Add(assign);
             }
@@ -690,7 +694,7 @@ internal static class ExpressionBuilder
             childSrcDetails.ReadableByName.TryGetValue(cDestProp.Name, out var cSrcProp);
             if (cSrcProp == null) continue;
 
-            var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, cDestProp);
+            var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, cDestProp, globalConverters);
             if (assign == null) return null;
             innerStmts.Add(assign);
         }
@@ -717,7 +721,8 @@ internal static class ExpressionBuilder
         ParameterExpression dVar,
         PropertyInfo srcProp,
         PropertyInfo destProp,
-        Dictionary<TypePair, TypeMap> allTypeMaps)
+        Dictionary<TypePair, TypeMap> allTypeMaps,
+        Dictionary<TypePair, Delegate>? globalConverters = null)
     {
         var srcType = srcProp.PropertyType;
         var destType = destProp.PropertyType;
@@ -745,13 +750,15 @@ internal static class ExpressionBuilder
             var elemCtor = TypeDetails.Get(destElem).ParameterlessCtor;
             if (elemTypeMap.BeforeMapAction != null || elemTypeMap.AfterMapAction != null) return null;
             if (elemTypeMap.MaxDepth > 0 || elemTypeMap.BaseMapTypePair.HasValue) return null;
-            if (elemTypeMap.PropertyMaps.Any(pm =>
-                pm.Condition != null || pm.FullCondition != null || pm.PreCondition != null
-                || pm.HasNullSubstitute || pm.CustomResolver != null))
-                return null;
+            for (int i = 0; i < elemTypeMap.PropertyMaps.Count; i++)
+            {
+                var pm = elemTypeMap.PropertyMaps[i];
+                if (pm.Condition != null || pm.FullCondition != null || pm.PreCondition != null
+                    || pm.HasNullSubstitute || pm.CustomResolver != null)
+                    return null;
+            }
 
-            // We'll build the mapping as a helper method call
-            // Actually, for simplicity and maximum speed, build a Func<TSrcElem, TDestElem>
+            // For maximum speed, build a Func<TSrcElem, TDestElem>
             var elemSrcParam = Expression.Parameter(srcElem, "es");
             var elemDestVar = Expression.Variable(destElem, "ed");
             var elemStmts = new List<Expression>();
@@ -781,7 +788,7 @@ internal static class ExpressionBuilder
                 {
                     elemSrcDetails.ReadableByName.TryGetValue(pm.SourceMemberName, out var sp);
                     if (sp == null) continue;
-                    var a = TryBuildSimpleInlineAssign(elemSrcParam, elemDestVar, sp, pm.DestinationProperty);
+                    var a = TryBuildSimpleInlineAssign(elemSrcParam, elemDestVar, sp, pm.DestinationProperty, globalConverters);
                     if (a == null) return null;
                     elemStmts.Add(a);
                 }
@@ -793,7 +800,7 @@ internal static class ExpressionBuilder
                 processed.Add(dp.Name);
                 elemSrcDetails.ReadableByName.TryGetValue(dp.Name, out var sp);
                 if (sp == null) continue;
-                var a = TryBuildSimpleInlineAssign(elemSrcParam, elemDestVar, sp, dp);
+                var a = TryBuildSimpleInlineAssign(elemSrcParam, elemDestVar, sp, dp, globalConverters);
                 if (a == null) return null;
                 elemStmts.Add(a);
             }
@@ -1159,7 +1166,7 @@ internal static class ExpressionBuilder
             // Try to inline the child map's property assignments directly into the
             // parent expression tree — eliminates delegate call + boxing overhead.
             var inlinedExpr = TryBuildInlinedNestedAssign(
-                sVar, dVar, srcProp, destProp, allTypeMaps, compiledMaps, ctxParam);
+                sVar, dVar, srcProp, destProp, allTypeMaps, compiledMaps, ctxParam, globalConverters);
             if (inlinedExpr != null)
                 return inlinedExpr;
 
@@ -1215,7 +1222,8 @@ internal static class ExpressionBuilder
         PropertyInfo destProp,
         Dictionary<TypePair, TypeMap> allTypeMaps,
         ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> compiledMaps,
-        ParameterExpression ctxParam)
+        ParameterExpression ctxParam,
+        Dictionary<TypePair, Delegate>? globalConverters = null)
     {
         var srcType = srcProp.PropertyType;
         var destType = destProp.PropertyType;
@@ -1229,10 +1237,13 @@ internal static class ExpressionBuilder
         if (childTypeMap.AfterMapAction != null) return null;
         if (childTypeMap.MaxDepth > 0) return null;
         if (childTypeMap.BaseMapTypePair.HasValue) return null;
-        if (childTypeMap.PropertyMaps.Any(pm =>
-            pm.Condition != null || pm.FullCondition != null || pm.PreCondition != null
-            || pm.HasNullSubstitute || pm.CustomResolver != null))
-            return null;
+        for (int i = 0; i < childTypeMap.PropertyMaps.Count; i++)
+        {
+            var pm = childTypeMap.PropertyMaps[i];
+            if (pm.Condition != null || pm.FullCondition != null || pm.PreCondition != null
+                || pm.HasNullSubstitute || pm.CustomResolver != null)
+                return null;
+        }
 
         var childDestDetailsTn = TypeDetails.Get(destType);
         var childDestCtor = childDestDetailsTn.ParameterlessCtor;
@@ -1293,8 +1304,8 @@ internal static class ExpressionBuilder
                 childSrcDetails.ReadableByName.TryGetValue(pm.SourceMemberName, out var cSrcProp);
                 if (cSrcProp == null) continue;
 
-                var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, pm.DestinationProperty);
-                if (assign == null) return null; // Property needs complex handling; bail out
+                var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, pm.DestinationProperty, globalConverters);
+                if (assign == null) return null;
                 innerStmts.Add(assign);
             }
         }
@@ -1308,8 +1319,8 @@ internal static class ExpressionBuilder
             childSrcDetails.ReadableByName.TryGetValue(cDestProp.Name, out var cSrcProp);
             if (cSrcProp == null) continue;
 
-            var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, cDestProp);
-            if (assign == null) return null; // Property needs complex handling; bail out
+            var assign = TryBuildSimpleInlineAssign(childSrcVar, childDestVar, cSrcProp, cDestProp, globalConverters);
+            if (assign == null) return null;
             innerStmts.Add(assign);
         }
 
@@ -1332,7 +1343,8 @@ internal static class ExpressionBuilder
     /// </summary>
     private static Expression? TryBuildSimpleInlineAssign(
         ParameterExpression srcVar, ParameterExpression destVar,
-        PropertyInfo srcProp, PropertyInfo destProp)
+        PropertyInfo srcProp, PropertyInfo destProp,
+        Dictionary<TypePair, Delegate>? globalConverters = null)
     {
         var srcType = srcProp.PropertyType;
         var destType = destProp.PropertyType;
@@ -1345,6 +1357,18 @@ internal static class ExpressionBuilder
 
         if (srcType == destType)
             return Expression.Assign(destAccess, srcAccess);
+
+        // ── Global type converter ─────────────────────────────────────────────
+        if (globalConverters != null)
+        {
+            var converterPair = new TypePair(srcType, destType);
+            if (globalConverters.TryGetValue(converterPair, out var converterDel))
+            {
+                var funcType = typeof(Func<,>).MakeGenericType(srcType, destType);
+                return Expression.Assign(destAccess,
+                    Expression.Invoke(Expression.Constant(converterDel, funcType), srcAccess));
+            }
+        }
 
         if (destType.IsAssignableFrom(srcType))
             return Expression.Assign(destAccess, Expression.Convert(srcAccess, destType));
@@ -1442,10 +1466,10 @@ internal static class ExpressionBuilder
             return;
         }
 
-        // Reference type: one null check, one local var, all assignments inside
+        // Reference type: assign nav to local var once, null-check the local var,
+        // then emit all assignments inside the IfThen — single property getter call.
         var navVar = Expression.Variable(navType, navProp.Name.ToLowerInvariant() + "_nav");
-        var innerStmts = new List<Expression>(items.Count + 1);
-        innerStmts.Add(Expression.Assign(navVar, navAccess));
+        var innerStmts = new List<Expression>(items.Count);
 
         foreach (var (nestedProp, destProp) in items)
         {
@@ -1454,11 +1478,14 @@ internal static class ExpressionBuilder
             innerStmts.Add(BuildFlattenedAssignExpr(nestedAccess, destAccess, nestedProp.PropertyType, destProp.PropertyType));
         }
 
-        stmts.Add(Expression.IfThen(
-            Expression.ReferenceNotEqual(
-                Expression.Convert(navAccess, typeof(object)),
-                Expression.Constant(null, typeof(object))),
-            Expression.Block(new[] { navVar }, innerStmts)));
+        stmts.Add(Expression.Block(
+            new[] { navVar },
+            Expression.Assign(navVar, navAccess),
+            Expression.IfThen(
+                Expression.ReferenceNotEqual(
+                    Expression.Convert(navVar, typeof(object)),
+                    Expression.Constant(null, typeof(object))),
+                Expression.Block(innerStmts))));
     }
 
     private static Expression BuildFlattenedAssignExpr(

--- a/src/EggMapper/Mapper.cs
+++ b/src/EggMapper/Mapper.cs
@@ -105,13 +105,21 @@ public sealed class Mapper : IMapper
     {
         if (source == null) return destination;
         var key = new TypePair(typeof(TSource), typeof(TDestination));
+
+        // Ctx-free typed delegate: zero boxing, zero ResolutionContext allocation.
+        // The Func<TSrc, TDest, TDest> signature already accepts an existing destination.
+        if (_config.FrozenCtxFreeMaps.TryGetValue(key, out var ctxFreeDel))
+            return ((Func<TSource, TDestination, TDestination>)ctxFreeDel)(source, destination);
+
         if (_config.FrozenMaps.TryGetValue(key, out var del))
         {
             var ctx = GetContext();
             return (TDestination)del(source, destination, ctx);
         }
-        if (_config.TryGetOrCompileOpenGenericMap(key, out var openDel, out _))
+        if (_config.TryGetOrCompileOpenGenericMap(key, out var openDel, out var openCtxFree))
         {
+            if (openCtxFree != null)
+                return ((Func<TSource, TDestination, TDestination>)openCtxFree)(source, destination);
             var ctx = GetContext();
             return (TDestination)openDel!(source, destination, ctx);
         }
@@ -202,25 +210,7 @@ public sealed class Mapper : IMapper
         {
             var typedDel = (Func<TSource, TDestination, TDestination>)ctxFreeDel;
             FastCache<TSource, TDestination>.Entry = new FastCache<TSource, TDestination>.CacheEntry(typedDel, _generation);
-
-            if (source is IList<TSource> lst)
-            {
-                var count = lst.Count;
-                var r = new List<TDestination>(count);
-                for (int i = 0; i < count; i++)
-                {
-                    var item = lst[i];
-                    r.Add(item == null ? default! : typedDel(item, default!));
-                }
-                return r;
-            }
-
-            var result = source is ICollection<TSource> col
-                ? new List<TDestination>(col.Count)
-                : new List<TDestination>();
-            foreach (var item in source)
-                result.Add(item == null ? default! : typedDel(item, default!));
-            return result;
+            return MapListWithCtxFreeDelegate(typedDel, source);
         }
 
         // Ctx-aware boxed delegate — or open generic on-demand compilation
@@ -233,23 +223,7 @@ public sealed class Mapper : IMapper
                     var typedDel = (Func<TSource, TDestination, TDestination>)openCtxFree;
                     FastCache<TSource, TDestination>.Entry =
                         new FastCache<TSource, TDestination>.CacheEntry(typedDel, _generation);
-                    if (source is IList<TSource> openLst)
-                    {
-                        var count = openLst.Count;
-                        var r = new List<TDestination>(count);
-                        for (int i = 0; i < count; i++)
-                        {
-                            var item = openLst[i];
-                            r.Add(item == null ? default! : typedDel(item, default!));
-                        }
-                        return r;
-                    }
-                    var result2 = source is ICollection<TSource> col3
-                        ? new List<TDestination>(col3.Count)
-                        : new List<TDestination>();
-                    foreach (var item in source)
-                        result2.Add(item == null ? default! : typedDel(item, default!));
-                    return result2;
+                    return MapListWithCtxFreeDelegate(typedDel, source);
                 }
                 del = openDel!;
             }
@@ -287,6 +261,30 @@ public sealed class Mapper : IMapper
             }
             return resultList;
         }
+    }
+
+    private static List<TDestination> MapListWithCtxFreeDelegate<TSource, TDestination>(
+        Func<TSource, TDestination, TDestination> typedDel,
+        IEnumerable<TSource> source)
+    {
+        if (source is IList<TSource> lst)
+        {
+            var count = lst.Count;
+            var r = new List<TDestination>(count);
+            for (int i = 0; i < count; i++)
+            {
+                var item = lst[i];
+                r.Add(item == null ? default! : typedDel(item, default!));
+            }
+            return r;
+        }
+
+        var result = source is ICollection<TSource> col
+            ? new List<TDestination>(col.Count)
+            : new List<TDestination>();
+        foreach (var item in source)
+            result.Add(item == null ? default! : typedDel(item, default!));
+        return result;
     }
 
     private object MapInternal(object source, Type sourceType, Type destinationType, object? destination)

--- a/src/EggMapper/MapperConfiguration.cs
+++ b/src/EggMapper/MapperConfiguration.cs
@@ -35,9 +35,19 @@ public sealed class MapperConfiguration
 
     // Open generic templates: (srcGenericDef, destGenericDef) → TypeMap with open types.
     private readonly Dictionary<(Type, Type), TypeMap> _openGenericRegistrations;
-    // On-demand compiled delegates for closed generic pairs.
-    private readonly ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> _runtimeOpenGenericMaps = new();
-    private readonly ConcurrentDictionary<TypePair, Delegate> _runtimeCtxFreeOpenGenericMaps = new();
+
+    // Bundles both delegates for a compiled closed generic pair into one cache entry,
+    // reducing on-demand lookups from two ConcurrentDictionary reads to one.
+    private sealed class OpenGenericEntry(
+        Func<object, object?, ResolutionContext, object> boxed,
+        Delegate? ctxFree)
+    {
+        public readonly Func<object, object?, ResolutionContext, object> Boxed = boxed;
+        public readonly Delegate? CtxFree = ctxFree;
+    }
+
+    // On-demand compiled delegates for closed generic pairs — single dict, bundled entry.
+    private readonly ConcurrentDictionary<TypePair, OpenGenericEntry> _runtimeOpenGenericEntries = new();
 
     public MapperConfiguration(Action<IMapperConfigurationExpression> configure)
     {
@@ -196,14 +206,15 @@ public sealed class MapperConfiguration
         out Func<object, object?, ResolutionContext, object>? boxedDel,
         out Delegate? ctxFreeDel)
     {
-        // Fast path: already compiled on a previous call
-        if (_runtimeOpenGenericMaps.TryGetValue(key, out boxedDel))
+        // Fast path: single ConcurrentDictionary lookup for the bundled entry.
+        if (_runtimeOpenGenericEntries.TryGetValue(key, out var cached))
         {
-            _runtimeCtxFreeOpenGenericMaps.TryGetValue(key, out ctxFreeDel);
+            boxedDel   = cached.Boxed;
+            ctxFreeDel = cached.CtxFree;
             return true;
         }
 
-        boxedDel = null;
+        boxedDel   = null;
         ctxFreeDel = null;
 
         var srcType  = key.SourceType;
@@ -225,7 +236,8 @@ public sealed class MapperConfiguration
         // ConvertUsing overrides all property mapping — no expression tree needed.
         if (closedTypeMap.ConvertUsingFunc != null)
         {
-            _runtimeOpenGenericMaps[key] = closedTypeMap.ConvertUsingFunc;
+            var entry = new OpenGenericEntry(closedTypeMap.ConvertUsingFunc, null);
+            _runtimeOpenGenericEntries[key] = entry;
             boxedDel = closedTypeMap.ConvertUsingFunc;
             return true;
         }
@@ -236,9 +248,8 @@ public sealed class MapperConfiguration
         if (ctxFreeResult != null)
         {
             var boxed = Execution.ExpressionBuilder.CreateBoxedWrapper(srcType, destType, ctxFreeResult);
-            _runtimeCtxFreeOpenGenericMaps[key] = ctxFreeResult;
-            _runtimeOpenGenericMaps[key] = boxed;
-            boxedDel  = boxed;
+            _runtimeOpenGenericEntries[key] = new OpenGenericEntry(boxed, ctxFreeResult);
+            boxedDel   = boxed;
             ctxFreeDel = ctxFreeResult;
             return true;
         }
@@ -246,7 +257,7 @@ public sealed class MapperConfiguration
         // Fall back to flexible delegate path.
         var compiled = Execution.ExpressionBuilder.BuildMappingDelegate(
             closedTypeMap, _typeMaps, _compiledMaps, DefaultMaxDepth, _globalConverters);
-        _runtimeOpenGenericMaps[key] = compiled;
+        _runtimeOpenGenericEntries[key] = new OpenGenericEntry(compiled, null);
         boxedDel = compiled;
         return true;
     }


### PR DESCRIPTION
## Summary

Three rounds of systematic code review with fixes targeting correctness, runtime performance, and startup performance.

### Bug Fix
- **Double property getter call** in `EmitGroupedFlattenedAssigns`: the navigation property getter was invoked twice — once in the `IfThen` condition and once inside the block. Fixed by assigning to a local `navVar` before the `IfThen` and null-checking `navVar` instead.

### Runtime Performance
- **`Map<S,D>(src, dest)` overload**: now checks `FrozenCtxFreeMaps` first, eliminating boxing and `ResolutionContext` allocation for the common case. Also adds open-generic ctx-free fast path.
- **`MapListFallback` deduplication**: extracted `MapListWithCtxFreeDelegate` helper to eliminate a duplicated ctx-free loop between `FrozenCtxFreeMaps` and open-generic paths.
- **Open generic warm path**: merged two `ConcurrentDictionary` lookups (`_runtimeOpenGenericMaps` + `_runtimeCtxFreeOpenGenericMaps`) into one bundled `OpenGenericEntry` — halves ConcurrentDictionary reads on every warm-path call.

### Startup Performance
- **Replaced `.Any(pm => ...)` LINQ** in three inline-builder methods with index-based `for` loops — eliminates enumerator allocations during `MapperConfiguration` construction.

### Correctness
- **Threaded `globalConverters`** through `TryBuildSimpleInlineAssign` so global type converters (registered via `AddTypeConverter<S,D>()`) are correctly applied to child properties in nested object and collection inline maps.

## Test plan
- [x] All 281 tests pass on .NET 8, 9, and 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)