### PR TITLE
feat: ColdStartBenchmark — fair startup comparison (config + first Map per type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,26 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 
 #### ⚪ Startup / Config
 
+> **Note:** These numbers measure config *construction only* and are **not comparable** across libraries.
+> EggMapper compiles all expression tree delegates eagerly at construction time (pays upfront).
+> AutoMapper and Mapster defer compilation to the first `Map()` call (pays on first use).
+> See **Cold Start** below for the fair end-to-end comparison.
+
 | Method            | Mean         | Error      | StdDev     | Min          | Median       | Max          | Ratio | Rank | Gen0    | Gen1   | Allocated | Alloc Ratio |
 |------------------ |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|------:|-----:|--------:|-------:|----------:|------------:|
 | EggMapperStartup  | 5,546.378 μs | 21.0287 μs | 17.5599 μs | 5,517.859 μs | 5,548.003 μs | 5,583.931 μs | 1.000 |    3 | 15.6250 | 7.8125 | 336.36 KB |        1.00 |
 | AutoMapperStartup |   280.519 μs |  2.5210 μs |  2.2348 μs |   277.808 μs |   280.045 μs |   284.729 μs | 0.051 |    2 |  5.8594 |      - | 103.88 KB |        0.31 |
 | MapsterStartup    |     2.469 μs |  0.0245 μs |  0.0229 μs |     2.436 μs |     2.459 μs |     2.506 μs | 0.000 |    1 |  0.7019 | 0.0267 |  11.51 KB |        0.03 |
+
+#### ⚪ Cold Start (Config + First Map per Type Pair)
+
+> Measures total time from zero to having mapped one instance of each registered type pair —
+> the real-world cost of bringing a mapper online. AutoMapper and Mapster pay their deferred
+> compilation cost here; EggMapper's Map() calls are instant (already compiled above).
+
+<!-- COLD_START_RESULTS_START -->
+*Results pending — will be populated on next CI run.*
+<!-- COLD_START_RESULTS_END -->
 
 ---
 

--- a/src/EggMapper.Benchmarks/ColdStartBenchmark.cs
+++ b/src/EggMapper.Benchmarks/ColdStartBenchmark.cs
@@ -1,0 +1,90 @@
+using BenchmarkDotNet.Attributes;
+using EggMapper.Benchmarks.Models;
+using Mapster;
+
+namespace EggMapper.Benchmarks;
+
+/// <summary>
+/// Measures the total time from zero to having mapped one instance of every registered type pair.
+/// This is the real-world "cold start" cost: config creation + first Map() call per type pair.
+///
+/// Unlike StartupBenchmark (which only measures config construction), this benchmark exposes the
+/// lazy-compilation cost that AutoMapper and Mapster defer to first use. EggMapper pays upfront
+/// at config time; competitors pay here instead.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class ColdStartBenchmark
+{
+    private static readonly ModelObject _model = new()
+    {
+        Id = 1, Name = "test", BaseDate = 20230101, Value = 1.5,
+        Active = true, Email = "a@b.com", Status = 2, Country = "US"
+    };
+
+    private static readonly Customer _customer = new()
+    {
+        Id = 1, Name = "Alice",
+        HomeAddress = new() { Street = "1 Main St", City = "Boston", State = "MA", Zip = "02101", Country = "US" },
+        WorkAddress = new() { Street = "2 Work Ave", City = "Boston", State = "MA", Zip = "02102", Country = "US" }
+    };
+
+    private static readonly Foo _foo = new()
+    {
+        FooId = 1, FooName = "foo",
+        Inner = new() { InnerFooId = 2, InnerFooName = "inner" },
+        InnerFoos = [new() { InnerFooId = 3, InnerFooName = "inner2" }]
+    };
+
+    [Benchmark(Baseline = true)]
+    public ModelDto EggMapper()
+    {
+        var config = new global::EggMapper.MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<ModelObject, ModelDto>();
+            cfg.CreateMap<Customer, CustomerDTO>();
+            cfg.CreateMap<Address, AddressDTO>();
+            cfg.CreateMap<Foo, FooDest>();
+            cfg.CreateMap<InnerFoo, InnerFooDest>();
+        });
+        var mapper = config.CreateMapper();
+        // All delegates already compiled — these calls are instant
+        mapper.Map<Customer, CustomerDTO>(_customer);
+        mapper.Map<Foo, FooDest>(_foo);
+        return mapper.Map<ModelObject, ModelDto>(_model);
+    }
+
+    [Benchmark]
+    public ModelDto AutoMapper()
+    {
+        var config = new global::AutoMapper.MapperConfiguration(
+            (global::AutoMapper.IMapperConfigurationExpression cfg) =>
+            {
+                cfg.CreateMap<ModelObject, ModelDto>();
+                cfg.CreateMap<Customer, CustomerDTO>();
+                cfg.CreateMap<Address, AddressDTO>();
+                cfg.CreateMap<Foo, FooDest>();
+                cfg.CreateMap<InnerFoo, InnerFooDest>();
+            }, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+        var mapper = config.CreateMapper();
+        // These calls trigger lazy compilation for each type pair
+        mapper.Map<CustomerDTO>(_customer);   // compiles Customer+Address maps
+        mapper.Map<FooDest>(_foo);            // compiles Foo+InnerFoo maps
+        return mapper.Map<ModelDto>(_model);  // compiles ModelObject map
+    }
+
+    [Benchmark]
+    public ModelDto Mapster()
+    {
+        var config = new TypeAdapterConfig();
+        config.NewConfig<ModelObject, ModelDto>();
+        config.NewConfig<Customer, CustomerDTO>();
+        config.NewConfig<Address, AddressDTO>();
+        config.NewConfig<Foo, FooDest>();
+        config.NewConfig<InnerFoo, InnerFooDest>();
+        // These calls trigger lazy compilation for each type pair
+        _customer.Adapt<CustomerDTO>(config);
+        _foo.Adapt<FooDest>(config);
+        return _model.Adapt<ModelDto>(config);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ColdStartBenchmark` measuring config creation + first `Map()` call per type pair — the real end-to-end cold start cost
- Adds explanatory note to the README startup table: AutoMapper/Mapster defer `LambdaExpression.Compile()` to first use, so their low startup numbers exclude actual compilation cost

## Why

The existing `StartupBenchmark` makes EggMapper look ~20× slower than AutoMapper at startup, but this is misleading:
- **EggMapper**: pays all compilation cost at `MapperConfiguration` construction (5,546 μs)
- **AutoMapper**: only stores metadata at construction (280 μs) — compilation happens lazily on first `Map()` call
- **Mapster**: stores config only (2 μs) — compiles on first use

`ColdStartBenchmark` measures `CreateConfig() + Map() × 3 type pairs`, exposing the deferred cost and giving a fair apples-to-apples comparison.

## Test plan
- [x] `dotnet build` clean (0 errors)
- [x] Benchmark compiles and runs under `--filter *ColdStart*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)