### PR TITLE
chore: broaden settings.local.json gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ __pycache__/
 ## OS
 .DS_Store
 Thumbs.db
-/.claude/settings.local.json
+settings.local.json


### PR DESCRIPTION
## Summary

Replaces `/.claude/settings.local.json` (path-specific) with `settings.local.json` (matches any directory).

Covers the `.claude/settings.local.json` case and any future `settings.local.json` files in other directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)