### PR TITLE
fix: nullable source in Map<TDest>(object?) — null returns default

### DIFF
--- a/src/EggMapper.UnitTests/EdgeCaseTests.cs
+++ b/src/EggMapper.UnitTests/EdgeCaseTests.cs
@@ -122,13 +122,13 @@ public class EdgeCaseTests
         act.Should().Throw<InvalidOperationException>().Which.Message.Should().Contain("No mapping configured");
     }
 
-    // ── Null source with Map<TDest>(object) ─────────────────────────────────
+    // ── Null source with Map<TDest>(object?) returns default ────────────────
     [Fact]
-    public void Map_NullObjectSource_ThrowsArgumentNullException()
+    public void Map_NullObjectSource_ReturnsDefault()
     {
         var mapper = new MapperConfiguration(cfg => cfg.CreateMap<FlatSource, FlatDest>()).CreateMapper();
-        var act = () => mapper.Map<FlatDest>(null!);
-        act.Should().Throw<ArgumentNullException>();
+        var result = mapper.Map<FlatDest>(null);
+        result.Should().BeNull();
     }
 }
 

--- a/src/EggMapper/IMapper.cs
+++ b/src/EggMapper/IMapper.cs
@@ -4,7 +4,7 @@ namespace EggMapper;
 
 public interface IMapper
 {
-    TDestination Map<TDestination>(object source);
+    TDestination Map<TDestination>(object? source);
     TDestination Map<TSource, TDestination>(TSource source);
     TDestination Map<TSource, TDestination>(TSource source, TDestination destination);
 
@@ -15,7 +15,7 @@ public interface IMapper
     /// <c>mapper.Map&lt;TDest&gt;(src, opt =&gt; opt.AfterMap((s, d) =&gt; ...))</c>.
     /// The source parameter of the callback is typed as <c>object</c>; cast it if needed.
     /// </summary>
-    TDestination Map<TDestination>(object source, Action<IMappingOperationOptions<object, TDestination>> opts);
+    TDestination Map<TDestination>(object? source, Action<IMappingOperationOptions<object, TDestination>> opts);
 
     /// <summary>
     /// Maps <paramref name="source"/> to <typeparamref name="TDestination"/> and then runs any

--- a/src/EggMapper/Mapper.cs
+++ b/src/EggMapper/Mapper.cs
@@ -30,9 +30,9 @@ public sealed class Mapper : IMapper
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public TDestination Map<TDestination>(object source)
+    public TDestination Map<TDestination>(object? source)
     {
-        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (source == null) return default!;
         return (TDestination)MapInternal(source, source.GetType(), typeof(TDestination), null);
     }
 
@@ -132,9 +132,9 @@ public sealed class Mapper : IMapper
     public object Map(object source, Type sourceType, Type destinationType)
         => MapInternal(source, sourceType, destinationType, null);
 
-    public TDestination Map<TDestination>(object source, Action<IMappingOperationOptions<object, TDestination>> opts)
+    public TDestination Map<TDestination>(object? source, Action<IMappingOperationOptions<object, TDestination>> opts)
     {
-        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (source == null) return default!;
         var mapped = (TDestination)MapInternal(source, source.GetType(), typeof(TDestination), null);
         if (opts != null)
         {


### PR DESCRIPTION
## Summary

- `IMapper.Map<TDest>(object source)` → `IMapper.Map<TDest>(object? source)`
- `IMapper.Map<TDest>(object source, Action<opts>)` → `IMapper.Map<TDest>(object? source, Action<opts>)`
- `null` source now returns `default(TDest)` instead of throwing `ArgumentNullException`

## Why

The standard mapper contract is `null → default`. AutoMapper behaves this way, and consumers (like DSP backend) pass potentially-null values to `Map<T>()`. The non-nullable parameter caused CS8604 warnings everywhere.

## Test plan

- [x] Updated `Map_NullObjectSource_ThrowsArgumentNullException` → `Map_NullObjectSource_ReturnsDefault`
- [x] All 305 unit tests pass on .NET 8/9/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)