### PR TITLE
fix: register IMapper as scoped for DI service resolution

### DIFF
--- a/src/EggMapper/Mapper.cs
+++ b/src/EggMapper/Mapper.cs
@@ -16,7 +16,7 @@ public sealed class Mapper : IMapper
     public Mapper(MapperConfiguration config)
     {
         _config = config;
-        _generation = System.Threading.Interlocked.Increment(ref _globalGeneration);
+        _generation = config.Generation;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -392,9 +392,9 @@ public sealed class Mapper : IMapper
             $"Call CreateMap<{sourceType.Name}, {destinationType.Name}>() in your mapper configuration.");
     }
 
-    // Global generation counter — incremented every time a new Mapper is created.
-    // Cached delegates are only valid for the current generation.
-    private static int _globalGeneration;
+    // Generation is tied to MapperConfiguration, not Mapper instances.
+    // All scoped Mapper instances from the same config share a generation,
+    // so FastCache stays valid across request scopes.
     private readonly int _generation;
 
     /// <summary>

--- a/src/EggMapper/MapperConfiguration.cs
+++ b/src/EggMapper/MapperConfiguration.cs
@@ -5,6 +5,12 @@ namespace EggMapper;
 
 public sealed class MapperConfiguration
 {
+    // Generation counter: each MapperConfiguration gets a unique id.
+    // All Mapper instances from the same config share this generation,
+    // so FastCache stays valid when IMapper is registered as scoped.
+    private static int _globalGeneration;
+    internal int Generation { get; }
+
     private readonly ConcurrentDictionary<TypePair, Func<object, object?, ResolutionContext, object>> _compiledMaps = new();
     private readonly Dictionary<TypePair, TypeMap> _typeMaps = new();
 
@@ -56,6 +62,7 @@ public sealed class MapperConfiguration
 
     public MapperConfiguration(Action<IMapperConfigurationExpression> configure)
     {
+        Generation = System.Threading.Interlocked.Increment(ref _globalGeneration);
         var expr = new MapperConfigurationExpression();
         configure(expr);
         ShouldMapProperty = expr.GetShouldMapProperty();

--- a/src/EggMapper/ServiceCollectionExtensions.cs
+++ b/src/EggMapper/ServiceCollectionExtensions.cs
@@ -9,7 +9,10 @@ public static class EggMapperServiceCollectionExtensions
     {
         var config = new MapperConfiguration(cfg => cfg.AddProfiles(assemblies));
         services.AddSingleton(config);
-        services.AddSingleton<IMapper>(sp =>
+        // Scoped so each request gets the request-scoped IServiceProvider.
+        // This allows MapFrom value resolvers to inject scoped services
+        // (e.g., DbContext, scoped business services) — matching AutoMapper behavior.
+        services.AddScoped<IMapper>(sp =>
         {
             var mapper = (Mapper)sp.GetRequiredService<MapperConfiguration>().CreateMapper();
             mapper.ServiceProvider = sp;
@@ -22,7 +25,7 @@ public static class EggMapperServiceCollectionExtensions
     {
         var config = new MapperConfiguration(configure);
         services.AddSingleton(config);
-        services.AddSingleton<IMapper>(sp =>
+        services.AddScoped<IMapper>(sp =>
         {
             var mapper = (Mapper)sp.GetRequiredService<MapperConfiguration>().CreateMapper();
             mapper.ServiceProvider = sp;


### PR DESCRIPTION
## Summary

- **`AddScoped<IMapper>` instead of `AddSingleton<IMapper>`**: Each HTTP request now gets a `Mapper` instance with the request-scoped `IServiceProvider`. This allows `MapFrom` value resolvers to inject scoped services (e.g., `IMediaAssetService`, `DbContext`).
- **Generation counter moved to `MapperConfiguration`**: All `Mapper` instances from the same config share a generation, so `FastCache` stays valid across request scopes — zero performance regression.

## Why

`MapFrom` with DI-injected value resolvers (e.g., `IMediaAssetService`) was failing with:
```
Cannot resolve scoped service 'Dsp.BL.MediaAssets.IMediaAssetService' from root provider
```
Because `IMapper` was singleton, `ServiceProvider` was the root provider, and scoped services can't be resolved from root. AutoMapper registers `IMapper` as scoped — this aligns EggMapper with that behavior.

## Performance impact

None. `MapperConfiguration` (singleton) holds all compiled delegates. `Mapper` is a lightweight wrapper (~32 bytes) that just references the config + scoped `IServiceProvider`. The `FastCache` generation is tied to the config, not the mapper instance, so cache hits are preserved.

## Test plan

- [x] All 308 unit tests pass on net8.0, net9.0, net10.0
- [ ] CI passes
- [ ] DSP `ProductTrackProxy → ProductTrackSearchResponse` with `IMediaAssetService` injection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)