### PR TITLE
chore: auto-update README benchmarks via PR, include Cold Start

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write        # needed to create benchmark-update branches
   pull-requests: write   # needed to post PR comments
 
 jobs:
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN || github.token }}
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
@@ -69,6 +71,38 @@ jobs:
           path: |
             src/EggMapper.Benchmarks/BenchmarkDotNet.Artifacts/
             benchmark-report.md
+
+      # ── Update README on push to main ──────────────────────────────────
+      # Creates a PR with updated benchmark tables (can't push to protected main).
+      - name: Update README with benchmark results
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/update-readme-benchmarks.py \
+            src/EggMapper.Benchmarks/BenchmarkDotNet.Artifacts \
+            README.md
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+
+          if git diff --cached --quiet; then
+            echo "No benchmark changes to commit."
+            exit 0
+          fi
+
+          BRANCH="chore/update-benchmarks-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "${BRANCH}"
+          git commit -m "chore: update benchmark results in README [skip ci]"
+          git push origin "${BRANCH}"
+
+          # Create PR (auto-merge will handle it)
+          gh pr create \
+            --title "chore: update benchmark results in README" \
+            --body "Automated benchmark update from CI run #${{ github.run_number }}." \
+            --head "${BRANCH}" \
+            --base main
 
       # ── Post detailed comment on PRs ───────────────────────────────────
       - name: Post PR comment

--- a/README.md
+++ b/README.md
@@ -215,13 +215,7 @@ dotnet run --configuration Release -f net10.0 -- --filter * --exporters json mar
 > the real-world cost of bringing a mapper online. AutoMapper and Mapster pay their deferred
 > compilation cost here; EggMapper's Map() calls are instant (already compiled above).
 
-<!-- COLD_START_RESULTS_START -->
-> EggMapper compiles **all** expression trees eagerly at config time — competitors defer to first `Map()` call.
-> Once running, EggMapper's `Map()` calls are near-instant while competitors pay on first use per type pair.
-> See the **Startup** table above for config-only cost, and the runtime tables for steady-state performance.
->
-> Full cold start results are available in the [benchmark CI artifacts](https://github.com/eggspot/EggMapper/actions/workflows/benchmarks.yml).
-<!-- COLD_START_RESULTS_END -->
+*Cold Start results will be populated by the next [benchmark CI run](https://github.com/eggspot/EggMapper/actions/workflows/benchmarks.yml).*
 
 ---
 

--- a/scripts/update-readme-benchmarks.py
+++ b/scripts/update-readme-benchmarks.py
@@ -47,6 +47,7 @@ BENCHMARK_ORDER: list[tuple[str, str]] = [
     ("DeepCollectionBenchmark",   "🔴 Deep Collection (100 items, nested)"),
     ("LargeCollectionBenchmark",  "⚫ Large Collection (1,000 items)"),
     ("StartupBenchmark",          "⚪ Startup / Config"),
+    ("ColdStartBenchmark",        "⚪ Cold Start (Config + First Map per Type Pair)"),
 ]
 
 # Short scenario labels used in the summary table (omits Startup)


### PR DESCRIPTION
## Summary

- **Cold Start in parse script**: Added `ColdStartBenchmark` to `BENCHMARK_ORDER` in `update-readme-benchmarks.py` so Cold Start results appear in README alongside all other benchmarks
- **Benchmark workflow creates PR**: On push to main, the workflow creates a PR with updated README benchmark tables instead of pushing directly (which is blocked by branch protection)
- **Cleaned up README**: Removed stale "Results pending" placeholder for Cold Start section

Next benchmark CI run on main will auto-create a PR with all results including Cold Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)