### PR TITLE
fix: MapFrom with nested type uses registered mapping

### DIFF
--- a/src/EggMapper.UnitTests/EdgeCaseTests.cs
+++ b/src/EggMapper.UnitTests/EdgeCaseTests.cs
@@ -216,9 +216,78 @@ public class EdgeCaseTests
         result[1].Id!.Value.Should().Be(2);
         result[1].Name.Should().Be("b_mapped");
     }
+
+    // ── MapFrom returning a different type that has a registered map ───────
+    [Fact]
+    public void Map_MapFromReturnsNestedType_UsesRegisteredMapping()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceWithNested, DestWithMapped>()
+                .ForMember(d => d.Nested, o => o.MapFrom(s => s.Inner));
+            cfg.CreateMap<NestedInnerSrc, NestedInnerDst>();
+        }).CreateMapper();
+
+        var src = new SourceWithNested { Name = "parent", Inner = new NestedInnerSrc { Value = 42 } };
+        var result = mapper.Map<SourceWithNested, DestWithMapped>(src);
+
+        result.Name.Should().Be("parent");
+        result.Nested.Should().NotBeNull();
+        result.Nested!.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Map_MapFromReturnsNullNestedType_ReturnsNull()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceWithNested, DestWithMapped>()
+                .ForMember(d => d.Nested, o => o.MapFrom(s => s.Inner));
+            cfg.CreateMap<NestedInnerSrc, NestedInnerDst>();
+        }).CreateMapper();
+
+        var src = new SourceWithNested { Name = "parent", Inner = null };
+        var result = mapper.Map<SourceWithNested, DestWithMapped>(src);
+
+        result.Name.Should().Be("parent");
+        result.Nested.Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_MapFromReturnsCollection_UsesRegisteredElementMapping()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceWithNestedList, DestWithMappedList>()
+                .ForMember(d => d.Items, o => o.MapFrom(s => s.Inners));
+            cfg.CreateMap<NestedInnerSrc, NestedInnerDst>();
+        }).CreateMapper();
+
+        var src = new SourceWithNestedList
+        {
+            Inners = new List<NestedInnerSrc>
+            {
+                new() { Value = 1 },
+                new() { Value = 2 }
+            }
+        };
+        var result = mapper.Map<SourceWithNestedList, DestWithMappedList>(src);
+
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Value.Should().Be(1);
+        result.Items[1].Value.Should().Be(2);
+    }
 }
 
-// ── Additional test models ──────────────────────────────────────────────────
+// ── Additional test models
+public class NestedInnerSrc { public int Value { get; set; } }
+public class NestedInnerDst { public int Value { get; set; } }
+public class SourceWithNested { public string? Name { get; set; } public NestedInnerSrc? Inner { get; set; } }
+public class DestWithMapped { public string? Name { get; set; } public NestedInnerDst? Nested { get; set; } }
+public class SourceWithNestedList { public List<NestedInnerSrc> Inners { get; set; } = []; }
+public class DestWithMappedList { public List<NestedInnerDst> Items { get; set; } = []; }
+
+// ────────────────────────────────────────────────────────────────────────────── ──────────────────────────────────────────────────
 public class BaseEntity
 {
     public int Id { get; set; }

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -1861,7 +1861,7 @@ internal static class ExpressionBuilder
                         "IMemberValueResolver requires DI. Use services.AddEggMapper() for dependency injection.");
                 var resolver = factory(ctx.ServiceProvider);
                 var val = resolver(src, dest, null, ctx);
-                setter(dest, ConvertValue(val, destType));
+                setter(dest, MapOrConvert(val, destType, ctx));
             };
         }
 
@@ -1881,7 +1881,7 @@ internal static class ExpressionBuilder
                 if (fullCondition != null && !fullCondition(src, dest)) return;
 
                 var val = resolver(src, dest, null, ctx);
-                setter(dest, ConvertValue(val, destType));
+                setter(dest, MapOrConvert(val, destType, ctx));
             };
         }
 
@@ -1903,7 +1903,7 @@ internal static class ExpressionBuilder
 
                 var val = resolver(src, dest);
                 if (hasNullSub && val == null) val = nullSub;
-                setter(dest, ConvertValue(val, destType));
+                setter(dest, MapOrConvert(val, destType, ctx));
             };
         }
 
@@ -2614,6 +2614,27 @@ internal static class ExpressionBuilder
             }
         }
         return args;
+    }
+
+    /// <summary>
+    /// Resolves a value to the target type using registered mappings first, then ConvertValue.
+    /// Use this in all resolver/action paths that have a ResolutionContext available.
+    /// Handles Genre→GenreResponse, Tag→TagResponse, etc. where a registered map exists.
+    /// </summary>
+    private static object? MapOrConvert(object? value, Type targetType, ResolutionContext ctx)
+    {
+        if (value == null) return null;
+        var valueType = value.GetType();
+        if (targetType.IsAssignableFrom(valueType)) return value;
+
+        // Try registered mapping (e.g., Genre → GenreResponse)
+        if (ctx.Mapper != null)
+        {
+            try { return ctx.Mapper.Map(value, valueType, targetType); }
+            catch (InvalidOperationException) { } // no mapping registered — fall through
+        }
+
+        return ConvertValue(value, targetType);
     }
 
     private static object? ConvertValue(object? value, Type targetType)


### PR DESCRIPTION
## Summary

**Critical bug**: `MapFrom(s => s.PrimaryGenre)` where source returns `Genre` but destination property is `GenreResponse` was silently returning `null` — the flexible delegate's `ConvertValue` didn't know about registered mappings.

**Fix**: New `MapOrConvert()` helper tries the mapper first (`ctx.Mapper.Map(value, sourceType, destType)`) before falling back to `ConvertValue`. Applied to all 3 resolver paths:
- `CustomResolver` — `MapFrom(s => s.Something)`
- `ContextResolver` — `MapFrom((s, d, m, ctx) => ...)`
- `ValueResolverFactory` — `MapFrom<TResolver, TSource>(...)`

This fixes `Contributors`, `PrimaryGenre`, `SecondaryGenre`, `Tags`, `Label` and all other properties where `MapFrom` returns a type that has a separate registered mapping.

## Test plan

- [x] 313 unit tests pass on net8.0, net9.0, net10.0
- [x] 3 new regression tests for nested type mapping via MapFrom
- [ ] CI passes
- [ ] DSP ProductDetailsResponse has non-null Contributors, PrimaryGenre, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)