### PR TITLE
fix: implicit/explicit operator conversion (Id<T> to int)

### DIFF
--- a/src/EggMapper.UnitTests/EdgeCaseTests.cs
+++ b/src/EggMapper.UnitTests/EdgeCaseTests.cs
@@ -236,6 +236,32 @@ public class EdgeCaseTests
         result.Nested!.Value.Should().Be(42);
     }
 
+    // ── Implicit operator conversion (Id<T> → int pattern) ───────────────
+    [Fact]
+    public void Map_ImplicitOperatorConversion_ConvertsStrongIdToInt()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<StrongIdSource, IntIdDest>())
+            .CreateMapper();
+
+        var src = new StrongIdSource { ArtistId = new ImplicitId(42) };
+        var result = mapper.Map<StrongIdSource, IntIdDest>(src);
+        result.ArtistId.Should().Be(42);
+    }
+
+    [Fact]
+    public void Map_ImplicitOperatorConversion_WorksWithIgnoredProps()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+            cfg.CreateMap<StrongIdSource, IntIdDest>()
+                .ForMember(d => d.ArtistId, o => o.Ignore()))
+            .CreateMapper();
+
+        var src = new StrongIdSource { ArtistId = new ImplicitId(99) };
+        var result = mapper.Map<StrongIdSource, IntIdDest>(src);
+        result.ArtistId.Should().Be(0); // ignored, stays default
+    }
+
     [Fact]
     public void Map_MapFromReturnsNullNestedType_ReturnsNull()
     {
@@ -278,6 +304,16 @@ public class EdgeCaseTests
         result.Items[1].Value.Should().Be(2);
     }
 }
+
+// ── Implicit operator test models (simulates DSP's Id<T> → int) ──────────────
+public class ImplicitId
+{
+    public int Value { get; }
+    public ImplicitId(int value) => Value = value;
+    public static implicit operator int(ImplicitId? id) => id?.Value ?? 0;
+}
+public class StrongIdSource { public ImplicitId ArtistId { get; set; } = new(0); }
+public class IntIdDest { public int ArtistId { get; set; } }
 
 // ── Additional test models
 public class NestedInnerSrc { public int Value { get; set; } }

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -2637,6 +2637,43 @@ internal static class ExpressionBuilder
         return ConvertValue(value, targetType);
     }
 
+    /// <summary>
+    /// Searches for implicit/explicit conversion operators on both source and target types.
+    /// Handles nullable parameter types (e.g., op_Implicit(Id&lt;T&gt;? id) accepts Id&lt;T&gt; too).
+    /// </summary>
+    private static object? TryInvokeConversionOperator(object value, Type valueType, Type targetType)
+    {
+        const System.Reflection.BindingFlags staticPublic =
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static;
+
+        // Search both source and target types
+        foreach (var searchType in new[] { valueType, targetType })
+        {
+            foreach (var opName in new[] { "op_Implicit", "op_Explicit" })
+            {
+                var methods = searchType.GetMethods(staticPublic);
+                for (int i = 0; i < methods.Length; i++)
+                {
+                    var m = methods[i];
+                    if (m.Name != opName) continue;
+                    if (!targetType.IsAssignableFrom(m.ReturnType)) continue;
+
+                    var ps = m.GetParameters();
+                    if (ps.Length != 1) continue;
+
+                    // Direct match or nullable-accepting (Id<T>? accepts Id<T>)
+                    var paramType = ps[0].ParameterType;
+                    if (paramType.IsAssignableFrom(valueType))
+                    {
+                        try { return m.Invoke(null, new[] { value }); }
+                        catch { }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     private static object? ConvertValue(object? value, Type targetType)
     {
         if (value == null) return null;
@@ -2651,7 +2688,13 @@ internal static class ExpressionBuilder
         if (valueType.IsEnum && (underlying == typeof(string) || targetType == typeof(string)))
             return value.ToString();
 
-        // Implicit/explicit conversion operators (e.g., Id<T>(T entity))
+        // Implicit/explicit conversion operators (e.g., Id<Artist> → int via implicit operator)
+        // Search both source and target types for op_Implicit/op_Explicit that can convert.
+        // Handles nullable parameters (e.g., op_Implicit(Id<T>? id) → int) by checking
+        // if the parameter is assignable from the value type.
+        var result = TryInvokeConversionOperator(value, valueType, underlying);
+        if (result != null) return result;
+
         try
         {
             return Convert.ChangeType(value, underlying);


### PR DESCRIPTION
## Summary

Types with `implicit operator` (e.g., a strongly-typed `Id<T>` that has `implicit operator int(Id<T>? id)`) were not being converted by `ConvertValue` when convention-mapping matched properties by name but types differed. The null return from `ConvertValue` caused NRE when the setter tried to unbox null to a value type like `int`.

**Fix**: New `TryInvokeConversionOperator` method searches both source and target types for `op_Implicit` and `op_Explicit` methods. Handles nullable parameter types (e.g., `op_Implicit(Id<T>? id)` accepts `Id<T>` too). Runs before `Convert.ChangeType` and constructor search, matching C# compiler priority.

## Test plan
- [x] 315 unit tests pass on net8.0, net9.0, net10.0
- [x] 2 new regression tests for implicit operator conversion
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)