### PR TITLE
docs: update AI agent docs with ProjectTo, same-type, collection auto-map

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -146,10 +146,26 @@ CreateMap<Product, ProductDto>()
 ### IQueryable Projection (EF Core)
 
 ```csharp
-// In a repository or service
+// In a repository or service — expression tree passed to EF Core, translated to SQL
 var dtos = await dbContext.Products
-    .ProjectTo<ProductDto>(mapperConfig)
+    .Where(p => p.IsActive)
+    .ProjectTo<Product, ProductDto>(mapperConfig)
     .ToListAsync();
+
+// Equivalent to: .Select(p => new ProductDto { Name = p.Name, ... })
+// No in-memory mapping — all done in SQL
+```
+
+### Same-Type Auto-Mapping (T → T)
+
+```csharp
+// No CreateMap<T, T>() needed — works automatically for cloning/copying
+var copy = mapper.Map<Customer, Customer>(customer);
+copy.Id == customer.Id     // true — all properties copied
+copy != customer           // true — new instance
+
+// Also works through collections
+var copies = mapper.Map<List<Order>>(orders);
 ```
 
 ### ConvertUsing (Custom Type Converter)
@@ -200,6 +216,35 @@ var result = mapper.Map<List<ProductDto>>(products, opt =>
 });
 ```
 
+### Collection Auto-Mapping
+
+```csharp
+// No CreateMap<List<A>, List<B>>() needed — just register the element map
+cfg.CreateMap<Order, OrderDto>();
+
+// All these work automatically:
+mapper.Map<List<OrderDto>>(orders);                    // Map<TDest>(object)
+mapper.Map<List<Order>, List<OrderDto>>(orders);       // Map<TSrc, TDest>
+mapper.Map<IEnumerable<OrderDto>>(orders);             // interface dest
+mapper.Map<IList<OrderDto>>(orders);                   // IList dest
+```
+
+## Migration Cheat Sheet (AutoMapper → EggMapper)
+
+| AutoMapper | EggMapper | Notes |
+|-----------|-----------|-------|
+| `using AutoMapper;` | `using EggMapper;` | |
+| `services.AddAutoMapper(asm)` | `services.AddEggMapper(asm)` | |
+| `mapper.Map<Dest>(src)` | `mapper.Map<Dest>(src)` | Same API |
+| `mapper.Map<S, D>(src)` | `mapper.Map<S, D>(src)` | Same API |
+| `mapper.Map(src, dest)` | `mapper.Map(src, dest)` | Same API |
+| `.ProjectTo<Dest>(config)` | `.ProjectTo<Src, Dest>(config)` | Two type args |
+| `mapper.Map<List<D>>(list)` | `mapper.Map<List<D>>(list)` | Auto-maps elements |
+| `mapper.Map<T, T>(obj)` | `mapper.Map<T, T>(obj)` | No CreateMap needed |
+| `ForMember(...)` | `ForMember(...)` | Same API |
+| `ReverseMap()` | `ReverseMap()` | Same API |
+| `Profile` | `Profile` | Same base class |
+
 ## Key Differences from AutoMapper
 
 | Feature | AutoMapper | EggMapper |
@@ -211,4 +256,7 @@ var result = mapper.Map<List<ProductDto>>(products, opt =>
 | API compatibility | Original | Same API, drop-in replacement |
 | DI registration | AddAutoMapper() | AddEggMapper() |
 | EF Core proxies | Handled | Handled (base-type + interface walk) |
+| ProjectTo | `ProjectTo<Dest>(cfg)` | `ProjectTo<Src, Dest>(cfg)` |
+| Same-type T→T | Needs CreateMap | Auto-compiles on first use |
+| Null collections | Empty by default | Empty by default |
 | Source generator | No | No (runtime, but near source-gen speed) |

--- a/llms.txt
+++ b/llms.txt
@@ -86,22 +86,44 @@ public class MyProfile : Profile
 - CreateMap<S,D>() with ForMember, MapFrom, Ignore, ReverseMap
 - Profile-based configuration with assembly scanning
 - Nested object mapping (inlined expression trees)
-- Collection mapping (List, Array, HashSet, Dictionary)
-- Flattening (src.Address.Street -> dest.AddressStreet)
+- Collection auto-mapping: CreateMap<A,B>() enables Map<List<B>>(listOfA) automatically
+- Same-type auto-mapping: Map<T,T>(obj) works without CreateMap — auto-compiles property copy
+- Flattening (src.Address.Street -> dest.AddressStreet), multi-level supported
 - Constructor mapping (records, immutable types)
-- Before/After map hooks
+- Before/After map hooks (with ResolutionContext for DI access)
 - Conditional mapping
 - Null substitution
+- Null collections → empty by default (matches common convention)
 - MaxDepth for self-referencing types
 - Inheritance mapping (IncludeAllDerived)
 - Enum mapping (int <-> enum, string <-> enum)
 - ForPath for nested destination properties
 - Patch/partial mapping
-- IQueryable projection (ProjectTo for EF Core)
+- IQueryable projection: `source.ProjectTo<TSrc, TDest>(config)` for EF Core
 - Open generic mapping
 - Global type converters
 - Configuration validation
-- EF Core proxy/derived type resolution
+- EF Core proxy/derived type resolution (base-type + interface walk)
+
+## ProjectTo (EF Core IQueryable Projection)
+
+```csharp
+// Translates to SQL — no in-memory mapping
+var dtos = await dbContext.Products
+    .Where(p => p.IsActive)
+    .ProjectTo<Product, ProductDto>(mapperConfig)
+    .ToListAsync();
+```
+
+Note: EggMapper requires both type args: `ProjectTo<TSrc, TDest>(config)`
+
+## Migrating from AutoMapper
+
+1. Replace NuGet: `AutoMapper` → `EggMapper`
+2. Replace using: `using AutoMapper;` → `using EggMapper;`
+3. Replace DI: `AddAutoMapper(...)` → `AddEggMapper(...)`
+4. Replace ProjectTo: `.ProjectTo<Dest>(cfg)` → `.ProjectTo<Src, Dest>(cfg)`
+5. All CreateMap, ForMember, Profile, IMapper code works unchanged
 
 ## Performance
 


### PR DESCRIPTION
## Problem
AI coding agents (Claude, Copilot, Cursor) helping users with EggMapper don't know about:
- `ProjectTo<TSrc, TDest>(config)` — wrong signature in docs (showed one type arg)
- Same-type auto-mapping (T → T without CreateMap)
- Collection auto-mapping (Map<List<B>>(listOfA))
- Migration steps from AutoMapper

## Fix
Updated `llms.txt` and `llms-full.txt` with:
- Correct `ProjectTo` signature with EF Core example
- Same-type auto-mapping section
- Collection auto-mapping section
- Full migration cheat sheet table
- Expanded feature list

## Test plan
- [ ] Verify llms.txt renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)