### PR TITLE
feat: add review-docs agent + GitHub Pages docs site

### DIFF
--- a/.claude/agents/review-docs.md
+++ b/.claude/agents/review-docs.md
@@ -1,0 +1,76 @@
+# Review & Documentation Agent
+
+You are a code review and documentation agent for **EggMapper**, a high-performance .NET object-to-object mapping library.
+
+## When to use this agent
+
+Use `/review-docs` after making code changes to:
+1. Review the changes for correctness, thread safety, and performance
+2. Update AI agent docs (`llms.txt`, `llms-full.txt`) if public API changed
+3. Update `README.md` if user-facing features changed
+4. Update `CLAUDE.md` if architecture or development workflow changed
+
+## Instructions
+
+### Step 1: Identify what changed
+
+Run `git diff main...HEAD --stat` to see all changed files. Then read the actual diffs for `src/EggMapper/**` files.
+
+### Step 2: Code review
+
+For each changed source file in `src/EggMapper/`:
+
+- **Null safety**: Check all new code paths for potential NRE. Pay attention to nullable value type boxing (Nullable<T> boxes as T).
+- **Thread safety**: Any new shared mutable state? New ConcurrentDictionary usage correct? ThreadStatic context leaks?
+- **Performance**: Any allocations in hot paths? Any LINQ in loops? Any boxing of value types?
+- **Error messages**: Do new exceptions use `TypeNameHelper.Readable()` for type names? Do they show which property/member failed?
+- **Consistency**: Does the new code handle ALL Map overloads consistently? (Map<D>(obj), Map<S,D>(src), Map<S,D>(src,dest), MapInternal, MapList, Patch)
+
+Report issues found with file:line references.
+
+### Step 3: Update AI docs if needed
+
+Check if ANY of these changed:
+- Public API (new methods, new overloads, changed signatures)
+- New features (same-type auto-map, collection auto-map, etc.)
+- Behavior changes (null handling, error messages, DI lifecycle)
+
+If yes, update:
+
+**`llms.txt`** (concise, for AI agent discovery):
+- Feature list in "Supported Features" section
+- Migration steps if API changed
+- Quick examples for new features
+
+**`llms-full.txt`** (detailed, for AI agent code generation):
+- Full code examples with correct signatures
+- Migration cheat sheet table
+- Key differences table
+
+### Step 4: Update README if needed
+
+Only update README sections that are affected by the changes:
+- Feature list
+- Quick start examples
+- API reference
+
+Do NOT touch benchmark tables (those are auto-updated by CI).
+
+### Step 5: Update CLAUDE.md if needed
+
+Only update if:
+- New files added to the architecture
+- Build/test commands changed
+- New development patterns established
+- Key performance techniques changed
+
+## Output format
+
+```
+## Review Summary
+- [x] Code review: N issues found (list them)
+- [x] llms.txt: updated / no changes needed
+- [x] llms-full.txt: updated / no changes needed
+- [x] README.md: updated / no changes needed
+- [x] CLAUDE.md: updated / no changes needed
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,7 @@
-{}
+{
+  "permissions": {
+    "additionalDirectories": [
+      "d:\\Work\\eg\\product\\src\\EggMapper\\.claude"
+    ]
+  }
+}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,8 @@
+title: EggMapper
+description: Fastest .NET runtime object-to-object mapper. Drop-in replacement for AutoMapper — same API, 2-5x faster.
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+  - jekyll-remote-theme
+
+url: https://eggspot.github.io
+baseurl: /EggMapper

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,68 @@
+---
+layout: default
+title: EggMapper
+---
+
+# EggMapper
+
+**Fastest .NET runtime object-to-object mapper.** Drop-in replacement for AutoMapper — same API, 2-5x faster, MIT licensed.
+
+## Why EggMapper?
+
+| | AutoMapper | EggMapper |
+|---|-----------|-----------|
+| **License** | Commercial (v13+) | MIT (free forever) |
+| **Performance** | Baseline | 2-5x faster |
+| **Allocations** | Extra per-map | Zero extra |
+| **Runtime reflection** | Yes | No (compiled expressions) |
+| **API** | Original | Same API, drop-in |
+
+## Install
+
+```bash
+dotnet add package EggMapper
+```
+
+## 30-Second Quick Start
+
+```csharp
+using EggMapper;
+
+var config = new MapperConfiguration(cfg =>
+{
+    cfg.CreateMap<Customer, CustomerDto>()
+        .ForMember(d => d.FullName, o => o.MapFrom(s => $"{s.First} {s.Last}"));
+});
+
+var mapper = config.CreateMapper();
+var dto = mapper.Map<CustomerDto>(customer);
+```
+
+## Key Features
+
+- **Same API as AutoMapper** — CreateMap, ForMember, Profile, IMapper
+- **Zero runtime reflection** — all delegates compiled as expression trees
+- **Zero extra allocations** — matches hand-written mapping code
+- **Collection auto-mapping** — `Map<List<B>>(listOfA)` works with just `CreateMap<A,B>()`
+- **Same-type auto-mapping** — `Map<T,T>(obj)` creates a copy without any configuration
+- **EF Core ProjectTo** — `query.ProjectTo<Src, Dest>(config)` translates to SQL
+- **DI integration** — `services.AddEggMapper(assembly)` with scoped IServiceProvider
+- **EF Core proxy support** — base-type + interface walk for lazy-loading proxies
+
+## Documentation
+
+- [Quick Start](quick-start) — Install, DI, Profiles, Collections
+- [Getting Started](Getting-Started) — Detailed walkthrough
+- [Configuration](Configuration) — MapperConfiguration, Profiles, Validation
+- [API Reference](API-Reference) — All Map overloads, ForMember options
+- [Advanced Features](Advanced-Features) — ProjectTo, Open Generics, Inheritance, Hooks
+- [Dependency Injection](Dependency-Injection) — ASP.NET, Blazor, gRPC, Windows Service
+- [Profiles](Profiles) — Organizing mappings into profile classes
+- [Migration Guide](Migration-Guide) — Runtime to Compile-Time tiers
+- [Performance](Performance) — Benchmark results vs all competitors
+
+## Links
+
+- [NuGet Package](https://www.nuget.org/packages/EggMapper)
+- [GitHub Repository](https://github.com/eggspot/EggMapper)
+- [Report Issues](https://github.com/eggspot/EggMapper/issues)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,110 @@
+---
+layout: default
+title: Quick Start
+---
+
+# Quick Start
+
+## Installation
+
+```bash
+dotnet add package EggMapper
+```
+
+No separate DI package needed — `AddEggMapper()` is included.
+
+Supported frameworks: `netstandard2.0`, `net462`, `net8.0`, `net9.0`, `net10.0`
+
+## Basic Usage
+
+```csharp
+using EggMapper;
+
+// 1. Configure mappings
+var config = new MapperConfiguration(cfg =>
+{
+    cfg.CreateMap<Product, ProductDto>();
+});
+
+// 2. Create mapper
+var mapper = config.CreateMapper();
+
+// 3. Map
+var dto = mapper.Map<ProductDto>(product);
+```
+
+## Dependency Injection (ASP.NET / Blazor / gRPC)
+
+```csharp
+// Program.cs
+builder.Services.AddEggMapper(typeof(MyProfile).Assembly);
+
+// Controller or service — inject IMapper
+public class ProductsController(IMapper mapper)
+{
+    public IActionResult Get(int id)
+    {
+        var product = db.Products.Find(id);
+        return Ok(mapper.Map<ProductDto>(product));
+    }
+}
+```
+
+`IMapper` is registered as **Transient** (each injection gets a fresh instance with the caller's scoped `IServiceProvider`). `MapperConfiguration` is **Singleton**.
+
+## Profiles
+
+Organize mappings into profile classes:
+
+```csharp
+public class ProductProfile : Profile
+{
+    public ProductProfile()
+    {
+        CreateMap<Product, ProductDto>()
+            .ForMember(d => d.FullName, o => o.MapFrom(s => $"{s.FirstName} {s.LastName}"))
+            .ForMember(d => d.Secret, o => o.Ignore());
+
+        CreateMap<OrderItem, OrderItemDto>();
+    }
+}
+
+// Register all profiles from an assembly
+builder.Services.AddEggMapper(typeof(ProductProfile).Assembly);
+```
+
+## Collection Mapping
+
+```csharp
+// Optimized batch mapping
+List<ProductDto> dtos = mapper.MapList<Product, ProductDto>(products);
+
+// Also works via Map<> — auto-detects collections
+var dtos = mapper.Map<List<ProductDto>>(products);
+```
+
+No `CreateMap<List<Product>, List<ProductDto>>()` needed — just the element map.
+
+## EF Core ProjectTo
+
+```csharp
+// Translates to SQL — no in-memory mapping
+var dtos = await dbContext.Products
+    .Where(p => p.IsActive)
+    .ProjectTo<Product, ProductDto>(mapperConfig)
+    .ToListAsync();
+```
+
+## Same-Type Mapping (Cloning)
+
+```csharp
+// No CreateMap needed — auto-compiles on first use
+var copy = mapper.Map<Customer, Customer>(customer);
+```
+
+## Configuration Validation
+
+```csharp
+var config = new MapperConfiguration(cfg => { ... });
+config.AssertConfigurationIsValid(); // Throws if any dest members unmapped
+```


### PR DESCRIPTION
## What's new

### 1. Review & Docs Agent (`.claude/agents/review-docs.md`)
A Claude Code agent that reviews code changes and updates documentation:
- Code review for correctness, thread safety, performance
- Updates `llms.txt` / `llms-full.txt` when public API changes
- Updates README/CLAUDE.md when features change

### 2. GitHub Pages Docs Site
- **Landing page** (`docs/index.md`) — feature highlights, install, navigation
- **Quick start** (`docs/quick-start.md`) — DI, collections, ProjectTo, same-type mapping
- **Jekyll config** (`docs/_config.yml`) — minimal theme, auto-builds
- Links to all existing wiki docs (API Reference, Advanced Features, Migration Guide, etc.)

### 3. Pages Deployment Workflow
- Auto-deploys `docs/` to GitHub Pages on push to main
- Path-filtered: only runs when `docs/**` changes
- Uses `actions/jekyll-build-pages` for zero-config build

## After merge
Enable GitHub Pages in **repo Settings → Pages → Source: GitHub Actions**.

The site will be live at: `https://eggspot.github.io/EggMapper/`

## Test plan
- [ ] Verify docs render on GitHub Pages after enabling
- [ ] Verify agent file is accessible in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)