### PR TITLE
docs: polish HTML site — prev/next nav, sitemap, 404

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found — EggMapper</title>
+  <link rel="icon" href="favicon.ico">
+  <link rel="stylesheet" href="assets/css/eggspot.css">
+  <style>
+    .not-found {
+      display: flex; flex-direction: column; align-items: center;
+      justify-content: center; text-align: center;
+      min-height: calc(100vh - 54px); padding: 2rem;
+    }
+    .not-found-code {
+      font-size: 6rem; font-weight: 800; line-height: 1;
+      color: var(--yellow); letter-spacing: -0.04em; margin-bottom: 0.5rem;
+    }
+    .not-found h1 { font-size: 1.75rem; margin-bottom: 0.75rem; }
+    .not-found p  { color: var(--text-muted); max-width: 400px; margin-bottom: 2rem; }
+  </style>
+</head>
+<body>
+<header class="site-header">
+  <a class="header-logo" href="index.html">
+    <img src="assets/images/logo.png" alt="EggMapper">
+    <span class="header-logo-text">Egg<span>Mapper</span></span>
+  </a>
+  <div class="header-spacer"></div>
+  <nav class="header-links">
+    <a class="header-link" href="https://github.com/eggspot/EggMapper" target="_blank" rel="noopener">GitHub</a>
+    <a class="header-link" href="https://www.nuget.org/packages/EggMapper" target="_blank" rel="noopener">NuGet</a>
+  </nav>
+</header>
+
+<main style="padding-top: 54px;">
+  <div class="not-found">
+    <div class="not-found-code">404</div>
+    <h1>Page not found</h1>
+    <p>The page you're looking for doesn't exist or has been moved.</p>
+    <div class="btn-group" style="justify-content: center;">
+      <a class="btn btn-primary" href="index.html">Go Home</a>
+      <a class="btn btn-outline" href="quick-start.html">Quick Start</a>
+    </div>
+  </div>
+</main>
+
+<footer class="site-footer" style="margin-left: 0;">
+  <span>EggMapper &mdash; MIT licensed &copy; <a href="https://eggspot.app">Eggspot</a>.</span>
+  <div class="footer-links">
+    <a href="https://github.com/eggspot/EggMapper" target="_blank" rel="noopener">GitHub</a>
+    <a href="https://www.nuget.org/packages/EggMapper" target="_blank" rel="noopener">NuGet</a>
+    <a href="https://github.com/eggspot/EggMapper/issues" target="_blank" rel="noopener">Issues</a>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/API-Reference.html
+++ b/docs/API-Reference.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>API Reference</h1>
 
-      <hr>
-
       <h2>Namespace <code>EggMapper</code></h2>
 
       <hr>
@@ -530,6 +528,8 @@ builder.Services.AddEggMapper(cfg =&gt;
 <pre><code>builder.Services.AddEggMapper(
     typeof(OrderProfile).Assembly,       // Web API layer
     typeof(ReportProfile).Assembly);     // Reporting layer</code></pre>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Performance.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Performance</span></a><a class="page-nav-link next" href="vs-automapper.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">vs AutoMapper</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Advanced-Features.html
+++ b/docs/Advanced-Features.html
@@ -709,6 +709,8 @@ public void AllMappings_ShouldBeValid()
         <li><strong>Forgetting to register <code>Ignore()</code> for validation</strong> — <code>AssertConfigurationIsValid()</code> will fail on unmapped destination properties. Use <code>Ignore()</code> for properties you intentionally leave unmapped.</li>
         <li><strong>Registering maps after construction</strong> — <code>MapperConfiguration</code> is immutable after construction. All maps must be registered in the constructor callback.</li>
       </ul>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Dependency-Injection.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Dependency Injection</span></a><a class="page-nav-link next" href="Performance.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Performance</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Configuration.html
+++ b/docs/Configuration.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>Configuration</h1>
 
-      <hr>
-
       <h2><code>MapperConfiguration</code></h2>
 
       <p><code>MapperConfiguration</code> is the <strong>entry point</strong> for EggMapper. You construct it once (typically at startup) and keep a single instance for the lifetime of the application.</p>
@@ -249,6 +247,8 @@ builder.Services.AddEggMapper(
         <li><strong>Not calling <code>AssertConfigurationIsValid()</code></strong> — Missing maps or typos in property names silently leave destination properties at their default values. Always validate in tests.</li>
         <li><strong>Registering the same type pair twice</strong> — The second <code>CreateMap&lt;S,D&gt;()</code> overwrites the first. This is usually a mistake. Keep each type pair in a single profile.</li>
       </ul>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Getting-Started.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Getting Started</span></a><a class="page-nav-link next" href="Profiles.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Profiles</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Dependency-Injection.html
+++ b/docs/Dependency-Injection.html
@@ -475,6 +475,8 @@ public void AllMappings_ShouldBeValid()
         <li><strong>Forgetting to scan the right assembly</strong> — If your profiles are in a separate class library, pass that assembly: <code>AddEggMapper(typeof(SomeProfile).Assembly)</code>.</li>
         <li><strong>Using <code>IMapper</code> in a static context</strong> — <code>IMapper</code> is designed for DI. In static helpers or extension methods, inject <code>MapperConfiguration</code> and call <code>CreateMapper()</code>.</li>
       </ul>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Profiles.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Profiles</span></a><a class="page-nav-link next" href="Advanced-Features.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Advanced Features</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Getting-Started.html
+++ b/docs/Getting-Started.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>Getting Started</h1>
 
-      <hr>
-
       <h2>Installation</h2>
 
       <h3>.NET CLI</h3>
@@ -256,6 +254,8 @@ public class OrderService(IMapper mapper, AppDbContext db)
           <tr><td>Complete API surface</td><td><a href="API-Reference.html">API Reference</a></td></tr>
         </tbody>
       </table></div>
+      <nav class="page-nav"><a class="page-nav-link prev" href="quick-start.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Quick Start</span></a><a class="page-nav-link next" href="Configuration.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Configuration</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Migration-Guide.html
+++ b/docs/Migration-Guide.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>Migration Guide</h1>
 
-      <hr>
-
       <h2>Migrating from AutoMapper to EggMapper</h2>
 
       <p>This is the most common migration path. EggMapper is a drop-in replacement for AutoMapper with the same API.</p>
@@ -316,6 +314,8 @@ public partial class OrderMapper
           <tr><td>DI singleton</td><td>N/A (static extension)</td><td><code>MyMapper.Instance</code> + constructor injection</td></tr>
         </tbody>
       </table></div>
+      <nav class="page-nav"><a class="page-nav-link prev" href="vs-automapper.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">vs AutoMapper</span></a><a class="page-nav-link next" href="Tier2-Getting-Started.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Attribute Mapper</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Performance.html
+++ b/docs/Performance.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>Performance</h1>
 
-      <hr>
-
       <h2>How EggMapper Achieves High Performance</h2>
 
       <p>EggMapper is the <strong>fastest .NET runtime object-to-object mapper</strong>, achieving near-manual mapping speed through these techniques:</p>
@@ -293,6 +291,8 @@ public void MappingConfiguration_IsValid()
 }</code></pre>
 
       <p>This ensures every map is exercised during the test run. It also catches missing maps and typos in property names before production.</p>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Advanced-Features.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Advanced Features</span></a><a class="page-nav-link next" href="API-Reference.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">API Reference</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Profiles.html
+++ b/docs/Profiles.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>Profiles</h1>
 
-      <hr>
-
       <p>Profiles let you group related <code>CreateMap</code> calls into a reusable class. This keeps your mapping configuration organised as the application grows.</p>
 
       <hr>
@@ -268,6 +266,8 @@ builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
         <li><strong>Missing nested type maps</strong> — If <code>OrderDto.Customer</code> is a <code>CustomerDto</code>, you need <code>CreateMap&lt;Customer, CustomerDto&gt;()</code> in the same or another profile. Use <code>AssertConfigurationIsValid()</code> to catch these.</li>
         <li><strong>Profile constructor with parameters</strong> — Profile constructors must be parameterless. Do not inject services into profiles.</li>
       </ul>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Configuration.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Configuration</span></a><a class="page-nav-link next" href="Dependency-Injection.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Dependency Injection</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Tier2-Getting-Started.html
+++ b/docs/Tier2-Getting-Started.html
@@ -177,6 +177,8 @@ public static partial class OrderToOrderDtoExtensions
           <tr><td>Want type errors at build time, not runtime</td><td><strong>Attribute Mapper</strong></td></tr>
         </tbody>
       </table></div>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Migration-Guide.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Migration Guide</span></a><a class="page-nav-link next" href="Tier3-Getting-Started.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Class Mapper</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/Tier3-Getting-Started.html
+++ b/docs/Tier3-Getting-Started.html
@@ -204,6 +204,8 @@ public partial class StatusMapper
           <tr><td>Property rename/ignore</td><td>Yes — <code>[MapProperty]</code>/<code>[MapIgnore]</code></td><td>via converter method</td></tr>
         </tbody>
       </table></div>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Tier2-Getting-Started.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Attribute Mapper</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/assets/css/eggspot.css
+++ b/docs/assets/css/eggspot.css
@@ -368,6 +368,26 @@ tr:hover td { background: rgba(255,255,255,0.018); }
   .feature-grid { grid-template-columns: 1fr; }
 }
 
+/* ── Prev / Next navigation ──────────────────── */
+.page-nav {
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 0.75rem;
+  margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border);
+}
+.page-nav-link {
+  display: flex; flex-direction: column; gap: 0.2rem;
+  padding: 0.75rem 1rem; border: 1px solid var(--border);
+  border-radius: var(--radius); flex: 1; min-width: 160px; max-width: 48%;
+  transition: border-color var(--ease), background var(--ease);
+  text-decoration: none;
+}
+.page-nav-link:hover { border-color: var(--yellow); background: var(--yellow-dim); }
+.page-nav-link.next { text-align: right; margin-left: auto; }
+.page-nav-label {
+  font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.08em; color: var(--text-muted);
+}
+.page-nav-title { font-size: 0.9rem; font-weight: 600; color: var(--yellow); }
+
 /* ── Global scrollbar ────────────────────────── */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/docs/quick-start.html
+++ b/docs/quick-start.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>Quick Start</h1>
 
-      <hr>
-
       <h2>Installation</h2>
 
       <pre><code>dotnet add package EggMapper</code></pre>
@@ -209,6 +207,8 @@ await db.SaveChangesAsync();</code></pre>
         <li><strong>Using the non-generic <code>Map&lt;TDest&gt;(object)</code> overload in hot paths</strong> — The generic <code>Map&lt;TSrc, TDst&gt;(src)</code> is faster because it uses the static generic cache with zero dictionary lookups.</li>
         <li><strong>Not calling <code>AssertConfigurationIsValid()</code> in tests</strong> — Missing maps silently leave destination properties at their default values.</li>
       </ul>
+      <nav class="page-nav"><a class="page-nav-link next" href="Getting-Started.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Getting Started</span></a></nav>
+
     </div>
   </main>
 </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://eggspot.github.io/EggMapper/</loc><priority>1.0</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/quick-start.html</loc><priority>0.9</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Getting-Started.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Configuration.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Profiles.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Dependency-Injection.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Advanced-Features.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Performance.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/API-Reference.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/vs-automapper.html</loc><priority>0.9</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Migration-Guide.html</loc><priority>0.8</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Tier2-Getting-Started.html</loc><priority>0.7</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Tier3-Getting-Started.html</loc><priority>0.7</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG1002.html</loc><priority>0.5</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG1003.html</loc><priority>0.5</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG2001.html</loc><priority>0.5</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG2002.html</loc><priority>0.5</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG3001.html</loc><priority>0.5</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG3002.html</loc><priority>0.5</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG3003.html</loc><priority>0.5</priority></url>
+</urlset>

--- a/docs/vs-automapper.html
+++ b/docs/vs-automapper.html
@@ -55,8 +55,6 @@
     <div class="content-wrapper">
       <h1>EggMapper vs AutoMapper</h1>
 
-      <hr>
-
       <h2>Why Switch from AutoMapper?</h2>
 
       <div class="note"><p>AutoMapper changed to a commercial license (RPL) starting v13. EggMapper is a <strong>free, MIT-licensed</strong> drop-in replacement that is also <strong>2-5x faster</strong> with <strong>zero extra allocations</strong>. Whether you need to replace AutoMapper due to the license change or you are evaluating mappers for a new project, EggMapper gives you the same API at significantly higher performance. Migration takes about 5 minutes.</p></div>
@@ -247,6 +245,8 @@ cfg.CreateMap&lt;Category, CategoryDto&gt;()
       <div class="note"><p>Most migrations are a find-and-replace. The entire process typically takes 5 minutes for a medium-sized project.</p></div>
 
       <p><a href="quick-start.html">Quick Start Guide</a> | <a href="API-Reference.html">API Reference</a> | <a href="https://github.com/eggspot/EggMapper" target="_blank" rel="noopener">GitHub</a></p>
+      <nav class="page-nav"><a class="page-nav-link prev" href="API-Reference.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">API Reference</span></a><a class="page-nav-link next" href="Migration-Guide.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Migration Guide</span></a></nav>
+
     </div>
   </main>
 </div>


### PR DESCRIPTION
## Summary

Polish pass on the static HTML docs site following the Jekyll migration.

- **Remove `<hr>` after `<h1>`** on 8 content pages — stray horizontal rule left over from the Jekyll markdown conversion
- **Prev / Next navigation** added to the bottom of all 12 content pages (Quick Start → Class Mapper sequential flow)
- **`sitemap.xml`** — all 20 pages with priority weights for SEO; `robots.txt` already references it
- **`404.html`** — branded error page with Home and Quick Start buttons

## Test plan

- [ ] Verify prev/next links are correct on each page (no skipped or reversed pages)
- [ ] Confirm `404.html` renders correctly at an invalid path on GitHub Pages
- [ ] Check `sitemap.xml` is valid XML and reachable at `/EggMapper/sitemap.xml`
- [ ] Spot-check that no `<hr>` appears directly under a page `<h1>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)