### PR TITLE
docs: Prism.js syntax highlighting with eggspot brand theme

### DIFF
--- a/docs/API-Reference.html
+++ b/docs/API-Reference.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Complete API reference for EggMapper — MapperConfiguration, IMapper, profiles, fluent builders.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -63,17 +64,17 @@
 
       <p>The root configuration object. Construct once at startup; keep as a singleton.</p>
 
-<pre><code>public sealed class MapperConfiguration</code></pre>
+<pre><code class="language-csharp">public sealed class MapperConfiguration</code></pre>
 
       <h4>Constructor</h4>
 
-<pre><code>public MapperConfiguration(Action&lt;IMapperConfigurationExpression&gt; configure)</code></pre>
+<pre><code class="language-csharp">public MapperConfiguration(Action&lt;IMapperConfigurationExpression&gt; configure)</code></pre>
 
       <p>Compiles all registered type maps into cached delegates during construction. This is the only expensive call — all subsequent mapping is near-zero overhead.</p>
 
       <p><strong>Example:</strong></p>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 var config = new MapperConfiguration(cfg =&gt;
 {
@@ -102,14 +103,14 @@ var config = new MapperConfiguration(cfg =&gt;
 
       <p><strong><code>CreateMapper()</code> example:</strong></p>
 
-<pre><code>IMapper mapper = config.CreateMapper();
+<pre><code class="language-csharp">IMapper mapper = config.CreateMapper();
 
 // mapper is lightweight — backed by the shared compiled cache
 // Safe to call multiple times; each returns a new wrapper around the same cache</code></pre>
 
       <p><strong><code>AssertConfigurationIsValid()</code> example:</strong></p>
 
-<pre><code>// In a unit test — catch missing maps before production
+<pre><code class="language-csharp">// In a unit test — catch missing maps before production
 [Fact]
 public void MappingConfiguration_ShouldBeValid()
 {
@@ -136,7 +137,7 @@ var results = dbContext.Orders
 
       <p>The runtime mapping interface. Resolve from DI or call <code>config.CreateMapper()</code>.</p>
 
-<pre><code>public interface IMapper</code></pre>
+<pre><code class="language-csharp">public interface IMapper</code></pre>
 
       <h4>Methods</h4>
 
@@ -176,13 +177,13 @@ var dto = mapper.Map&lt;OrderDto&gt;(entity);
 
       <p><strong><code>MapList&lt;TSrc, TDst&gt;(source)</code> — batch collection mapping:</strong></p>
 
-<pre><code>var orders = await db.Orders.ToListAsync();
+<pre><code class="language-csharp">var orders = await db.Orders.ToListAsync();
 List&lt;OrderDto&gt; dtos = mapper.MapList&lt;Order, OrderDto&gt;(orders);
 // Entire loop compiled as a single expression tree — near-manual speed</code></pre>
 
       <p><strong><code>Patch&lt;TSrc, TDst&gt;(source, destination)</code> — partial update:</strong></p>
 
-<pre><code>// API endpoint for PATCH /products/{id}
+<pre><code class="language-csharp">// API endpoint for PATCH /products/{id}
 app.MapPatch("/products/{id}", async (int id, UpdateProductRequest req, AppDbContext db, IMapper mapper) =&gt;
 {
     var product = await db.Products.FindAsync(id);
@@ -214,7 +215,7 @@ app.MapPatch("/products/{id}", async (int id, UpdateProductRequest req, AppDbCon
 
       <p><strong><code>CreateMap&lt;TSrc, TDst&gt;()</code> example:</strong></p>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 var config = new MapperConfiguration(cfg =&gt;
 {
@@ -224,7 +225,7 @@ var config = new MapperConfiguration(cfg =&gt;
 
       <p><strong><code>CreateMap(Type, Type)</code> — open generics:</strong></p>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 var config = new MapperConfiguration(cfg =&gt;
 {
@@ -238,7 +239,7 @@ var dto = mapper.Map&lt;Result&lt;Order&gt;, ResultDto&lt;Order&gt;&gt;(result);
 
       <p><strong><code>AddProfiles(assemblies)</code> example:</strong></p>
 
-<pre><code>var config = new MapperConfiguration(cfg =&gt;
+<pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
     cfg.AddProfiles(
         typeof(OrderProfile).Assembly,
         typeof(ReportProfile).Assembly));</code></pre>
@@ -271,21 +272,21 @@ var dto = mapper.Map&lt;Result&lt;Order&gt;, ResultDto&lt;Order&gt;&gt;(result);
 
       <p><strong><code>ForMember</code> with <code>MapFrom</code> — custom mapping expression:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;()
     .ForMember(d =&gt; d.CustomerName, o =&gt; o.MapFrom(s =&gt; s.Customer.FullName))
     .ForMember(d =&gt; d.TotalWithTax, o =&gt; o.MapFrom(s =&gt; s.Total * 1.1m))
     .ForMember(d =&gt; d.Status, o =&gt; o.MapFrom(s =&gt; s.Status.ToString()));</code></pre>
 
       <p><strong><code>ForMember</code> with <code>Ignore</code> — exclude sensitive data:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;User, UserDto&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;User, UserDto&gt;()
     .ForMember(d =&gt; d.PasswordHash, o =&gt; o.Ignore())
     .ForMember(d =&gt; d.SecurityStamp, o =&gt; o.Ignore())
     .ForMember(d =&gt; d.TwoFactorSecret, o =&gt; o.Ignore());</code></pre>
 
       <p><strong><code>ForMember</code> with <code>Condition</code> — conditional mapping:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.DiscountPrice,
                o =&gt; o.Condition(s =&gt; s.Discount &gt; 0))
     .ForMember(d =&gt; d.WarehouseLocation,
@@ -293,27 +294,27 @@ var dto = mapper.Map&lt;Result&lt;Order&gt;, ResultDto&lt;Order&gt;&gt;(result);
 
       <p><strong><code>ForMember</code> with <code>NullSubstitute</code> — fallback values:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.Description, o =&gt; o.NullSubstitute("No description available"))
     .ForMember(d =&gt; d.ImageUrl, o =&gt; o.NullSubstitute("/images/placeholder.png"));</code></pre>
 
       <p><strong><code>ForPath</code> — nested destination paths:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;OrderFlatDto, Order&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;OrderFlatDto, Order&gt;()
     .ForPath(d =&gt; d.Customer.Name, o =&gt; o.MapFrom(s =&gt; s.CustomerName))
     .ForPath(d =&gt; d.Customer.Address.City, o =&gt; o.MapFrom(s =&gt; s.ShippingCity))
     .ForPath(d =&gt; d.Customer.Address.PostalCode, o =&gt; o.MapFrom(s =&gt; s.ShippingZip));</code></pre>
 
       <p><strong><code>ReverseMap</code> — bidirectional mapping:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;().ReverseMap();
+<pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;().ReverseMap();
 // Equivalent to:
 // cfg.CreateMap&lt;Product, ProductDto&gt;();
 // cfg.CreateMap&lt;ProductDto, Product&gt;();</code></pre>
 
       <p><strong><code>BeforeMap</code> / <code>AfterMap</code> — lifecycle hooks:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;()
     .BeforeMap((src, dst) =&gt;
     {
         // Normalize data before mapping
@@ -327,14 +328,14 @@ var dto = mapper.Map&lt;Result&lt;Order&gt;, ResultDto&lt;Order&gt;&gt;(result);
 
       <p><strong><code>MaxDepth</code> — self-referencing types:</strong></p>
 
-<pre><code>// Category has Children: List&lt;Category&gt; (tree structure)
+<pre><code class="language-csharp">// Category has Children: List&lt;Category&gt; (tree structure)
 cfg.CreateMap&lt;Category, CategoryDto&gt;()
     .MaxDepth(3);
 // Maps 3 levels deep, then stops (children beyond depth 3 are null)</code></pre>
 
       <p><strong><code>IncludeBase</code> — polymorphic inheritance:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;Vehicle, VehicleDto&gt;();
+<pre><code class="language-csharp">cfg.CreateMap&lt;Vehicle, VehicleDto&gt;();
 cfg.CreateMap&lt;Car, CarDto&gt;().IncludeBase&lt;Vehicle, VehicleDto&gt;();
 cfg.CreateMap&lt;Truck, TruckDto&gt;().IncludeBase&lt;Vehicle, VehicleDto&gt;();
 
@@ -345,7 +346,7 @@ var dto = mapper.Map&lt;Car, CarDto&gt;(car);
 
       <p><strong><code>Validate</code> — post-mapping validation:</strong></p>
 
-<pre><code>cfg.CreateMap&lt;CreateOrderRequest, Order&gt;()
+<pre><code class="language-csharp">cfg.CreateMap&lt;CreateOrderRequest, Order&gt;()
     .Validate(d =&gt; d.CustomerName, n =&gt; !string.IsNullOrWhiteSpace(n), "Customer name is required")
     .Validate(d =&gt; d.Total, t =&gt; t &gt; 0, "Order total must be positive")
     .Validate(d =&gt; d.Lines, l =&gt; l.Count &gt; 0, "Order must have at least one line");</code></pre>
@@ -362,7 +363,7 @@ var dto = mapper.Map&lt;Car, CarDto&gt;(car);
 
       <p><strong>Example — real-world profile:</strong></p>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 public class ECommerceProfile : Profile
 {
@@ -467,7 +468,7 @@ catch (MappingValidationException ex)
 
       <h3><code>QueryableExtensions.ProjectTo&lt;TSrc, TDst&gt;()</code></h3>
 
-<pre><code>public static IQueryable&lt;TDst&gt; ProjectTo&lt;TSrc, TDst&gt;(
+<pre><code class="language-csharp">public static IQueryable&lt;TDst&gt; ProjectTo&lt;TSrc, TDst&gt;(
     this IQueryable&lt;TSrc&gt; source,
     MapperConfiguration config)</code></pre>
 
@@ -475,7 +476,7 @@ catch (MappingValidationException ex)
 
       <p><strong>Example:</strong></p>
 
-<pre><code>// All of these work with ProjectTo
+<pre><code class="language-csharp">// All of these work with ProjectTo
 var activeProducts = await dbContext.Products
     .Where(p =&gt; p.IsActive)
     .ProjectTo&lt;Product, ProductDto&gt;(config)
@@ -509,13 +510,13 @@ var page = await dbContext.Orders
 
       <p><strong>Assembly scanning:</strong></p>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
 
       <p><strong>Inline configuration:</strong></p>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 builder.Services.AddEggMapper(cfg =&gt;
 {
@@ -525,7 +526,7 @@ builder.Services.AddEggMapper(cfg =&gt;
 
       <p><strong>Multiple assemblies:</strong></p>
 
-<pre><code>builder.Services.AddEggMapper(
+<pre><code class="language-csharp">builder.Services.AddEggMapper(
     typeof(OrderProfile).Assembly,       // Web API layer
     typeof(ReportProfile).Assembly);     // Reporting layer</code></pre>
       <nav class="page-nav"><a class="page-nav-link prev" href="Performance.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Performance</span></a><a class="page-nav-link next" href="vs-automapper.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">vs AutoMapper</span></a></nav>
@@ -542,5 +543,7 @@ builder.Services.AddEggMapper(cfg =&gt;
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Advanced-Features.html
+++ b/docs/Advanced-Features.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Advanced EggMapper features — ForMember, conditions, hooks, ProjectTo, patch mapping, validation, open generics.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -59,7 +60,7 @@
 
       <p>Override the default convention for any destination property:</p>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 cfg.CreateMap&lt;Customer, CustomerDto&gt;()
     .ForMember(d =&gt; d.FullName,
@@ -69,7 +70,7 @@ cfg.CreateMap&lt;Customer, CustomerDto&gt;()
 
       <h3>Map from a computed expression</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;()
     .ForMember(d =&gt; d.DisplayPrice,
                opt =&gt; opt.MapFrom(s =&gt; $"{s.Currency} {s.Price:F2}"))
     .ForMember(d =&gt; d.TotalWithTax,
@@ -79,7 +80,7 @@ cfg.CreateMap&lt;Customer, CustomerDto&gt;()
 
       <h3>Map from a deeply nested source</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderFlatDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderFlatDto&gt;()
     .ForMember(d =&gt; d.CustomerName,
                opt =&gt; opt.MapFrom(s =&gt; s.Customer.FullName))
     .ForMember(d =&gt; d.CustomerEmail,
@@ -95,7 +96,7 @@ cfg.CreateMap&lt;Customer, CustomerDto&gt;()
 
       <p>Tell EggMapper to leave a destination property at its default value:</p>
 
-      <pre><code>cfg.CreateMap&lt;User, UserDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;User, UserDto&gt;()
     .ForMember(d =&gt; d.PasswordHash, opt =&gt; opt.Ignore())
     .ForMember(d =&gt; d.InternalId,   opt =&gt; opt.Ignore())
     .ForMember(d =&gt; d.SecurityStamp, opt =&gt; opt.Ignore());</code></pre>
@@ -108,12 +109,12 @@ cfg.CreateMap&lt;Customer, CustomerDto&gt;()
 
       <p>Register the inverse mapping in one call:</p>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;().ReverseMap();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;().ReverseMap();
 // Registers: Order -&gt; OrderDto  AND  OrderDto -&gt; Order</code></pre>
 
       <h3>Real-world use: API request/response symmetry</h3>
 
-      <pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;().ReverseMap();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;().ReverseMap();
 
 // Read: Entity -&gt; DTO
 var dto = mapper.Map&lt;Product, ProductDto&gt;(product);
@@ -127,7 +128,7 @@ var entity = mapper.Map&lt;ProductDto, Product&gt;(dto);</code></pre>
 
       <p>Write to a property deep in the destination object graph:</p>
 
-      <pre><code>cfg.CreateMap&lt;OrderFlatDto, Order&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;OrderFlatDto, Order&gt;()
     .ForPath(d =&gt; d.Customer.Name,
              opt =&gt; opt.MapFrom(s =&gt; s.CustomerName))
     .ForPath(d =&gt; d.Customer.Address.City,
@@ -143,13 +144,13 @@ var entity = mapper.Map&lt;ProductDto, Product&gt;(dto);</code></pre>
 
       <p>Declare maps for nested types and EggMapper uses them automatically:</p>
 
-      <pre><code>cfg.CreateMap&lt;Address,  AddressDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Address,  AddressDto&gt;();
 cfg.CreateMap&lt;Customer, CustomerDto&gt;();
 // CustomerDto.Address is mapped via the Address -&gt; AddressDto map</code></pre>
 
       <h3>Real-world example: Order with nested Customer and Address</h3>
 
-      <pre><code>// Entities
+      <pre><code class="language-csharp">// Entities
 public class Order
 {
     public int Id { get; set; }
@@ -196,21 +197,21 @@ var dto = mapper.Map&lt;Order, OrderDto&gt;(order);
         </tbody>
       </table></div>
 
-      <pre><code>cfg.CreateMap&lt;Order,    OrderDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order,    OrderDto&gt;();
 cfg.CreateMap&lt;Customer, CustomerDto&gt;();
 
 // CustomerDto.Orders (List&lt;OrderDto&gt;) mapped automatically from Customer.Orders (List&lt;Order&gt;)</code></pre>
 
       <h3>Batch mapping with <code>MapList</code></h3>
 
-      <pre><code>var orders = await db.Orders.ToListAsync();
+      <pre><code class="language-csharp">var orders = await db.Orders.ToListAsync();
 
 // Fully inlined compiled loop — near-manual speed
 List&lt;OrderDto&gt; dtos = mapper.MapList&lt;Order, OrderDto&gt;(orders);</code></pre>
 
       <h3>Array mapping</h3>
 
-      <pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;();
 
 Product[] products = GetProducts();
 var dtos = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);
@@ -222,28 +223,28 @@ var dtos = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);
 
       <h3><code>Condition</code> — skip if a value-level predicate fails</h3>
 
-      <pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.DiscountPrice,
                opt =&gt; opt.Condition(s =&gt; s.Discount &gt; 0));
 // DiscountPrice only set when there is actually a discount</code></pre>
 
       <h3><code>PreCondition</code> — skip the source read entirely</h3>
 
-      <pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.WarehouseCode,
                opt =&gt; opt.PreCondition(s =&gt; s.IsPhysical));
 // WarehouseCode not even read from source for digital products</code></pre>
 
       <h3>Full condition (source + destination)</h3>
 
-      <pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.Price,
                opt =&gt; opt.Condition((src, dst) =&gt; src.Price != dst.Price));
 // Only update price if it actually changed — useful with Map(src, existingDst)</code></pre>
 
       <h3>Real-world example: conditional mapping for API responses</h3>
 
-      <pre><code>cfg.CreateMap&lt;User, UserProfileDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;User, UserProfileDto&gt;()
     .ForMember(d =&gt; d.Email,
                opt =&gt; opt.Condition(s =&gt; s.EmailVerified))
     .ForMember(d =&gt; d.PhoneNumber,
@@ -257,7 +258,7 @@ var dtos = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);
 
       <p>Provide a fallback value when the source property is <code>null</code>:</p>
 
-      <pre><code>cfg.CreateMap&lt;Product, ProductDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.Description,
                opt =&gt; opt.NullSubstitute("No description available"))
     .ForMember(d =&gt; d.ImageUrl,
@@ -271,7 +272,7 @@ var dtos = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);
 
       <p>Run custom logic immediately before or after the mapping:</p>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;()
     .BeforeMap((src, dst) =&gt;
     {
         // Normalize or validate source data
@@ -286,7 +287,7 @@ var dtos = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);
 
       <h3>Use case: auditing mapped objects</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderAuditDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderAuditDto&gt;()
     .AfterMap((src, dst) =&gt;
     {
         dst.AuditTimestamp = DateTimeOffset.UtcNow;
@@ -302,14 +303,14 @@ var dtos = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);
 
       <p>Prevent infinite recursion on types that reference themselves:</p>
 
-      <pre><code>cfg.CreateMap&lt;Category, CategoryDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Category, CategoryDto&gt;()
     .MaxDepth(3);
 // Category.Children -&gt; CategoryDto.Children mapped up to depth 3
 // Beyond depth 3, Children is null</code></pre>
 
       <h3>Real-world example: organizational hierarchy</h3>
 
-      <pre><code>public class Department
+      <pre><code class="language-csharp">public class Department
 {
     public int Id { get; set; }
     public string Name { get; set; } = "";
@@ -322,7 +323,7 @@ cfg.CreateMap&lt;Department, DepartmentDto&gt;()
 
       <h3>Real-world example: threaded comments</h3>
 
-      <pre><code>public class Comment
+      <pre><code class="language-csharp">public class Comment
 {
     public int Id { get; set; }
     public string Body { get; set; } = "";
@@ -338,13 +339,13 @@ cfg.CreateMap&lt;Comment, CommentDto&gt;()
 
       <p>Map a derived type through the base type map:</p>
 
-      <pre><code>cfg.CreateMap&lt;Vehicle, VehicleDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Vehicle, VehicleDto&gt;();
 cfg.CreateMap&lt;Car, CarDto&gt;().IncludeBase&lt;Vehicle, VehicleDto&gt;();
 cfg.CreateMap&lt;Truck, TruckDto&gt;().IncludeBase&lt;Vehicle, VehicleDto&gt;();</code></pre>
 
       <h3>Real-world example: EF Core TPH (Table Per Hierarchy)</h3>
 
-      <pre><code>// EF Core entities using TPH inheritance
+      <pre><code class="language-csharp">// EF Core entities using TPH inheritance
 public abstract class Payment
 {
     public int Id { get; set; }
@@ -399,7 +400,7 @@ cfg.CreateMap&lt;BankTransferPayment, BankTransferPaymentDto&gt;()
 
       <p>Enums are mapped by value (numeric) by default. Properties with identical enum types are copied directly.</p>
 
-      <pre><code>public enum OrderStatus { Pending, Processing, Shipped, Delivered }
+      <pre><code class="language-csharp">public enum OrderStatus { Pending, Processing, Shipped, Delivered }
 public enum OrderStatusDto { Pending, Processing, Shipped, Delivered }
 
 cfg.CreateMap&lt;Order, OrderDto&gt;();
@@ -407,7 +408,7 @@ cfg.CreateMap&lt;Order, OrderDto&gt;();
 
       <h3>Enum to string</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;()
     .ForMember(d =&gt; d.StatusText, o =&gt; o.MapFrom(s =&gt; s.Status.ToString()));</code></pre>
 
       <hr>
@@ -416,14 +417,14 @@ cfg.CreateMap&lt;Order, OrderDto&gt;();
 
       <p>If the destination has a constructor whose parameter names match source property names, EggMapper uses it automatically:</p>
 
-      <pre><code>public record OrderDto(int Id, string CustomerName, decimal Total);
+      <pre><code class="language-csharp">public record OrderDto(int Id, string CustomerName, decimal Total);
 
 cfg.CreateMap&lt;Order, OrderDto&gt;();
 // Uses the positional constructor: new OrderDto(src.Id, src.CustomerName, src.Total)</code></pre>
 
       <h3>Record types with additional properties</h3>
 
-      <pre><code>public record ProductDto(int Id, string Name)
+      <pre><code class="language-csharp">public record ProductDto(int Id, string Name)
 {
     public decimal Price { get; init; }
     public string Category { get; init; } = "";
@@ -434,7 +435,7 @@ cfg.CreateMap&lt;Product, ProductDto&gt;();
 
       <h3>Immutable value objects</h3>
 
-      <pre><code>public class Money
+      <pre><code class="language-csharp">public class Money
 {
     public Money(decimal amount, string currency)
     {
@@ -463,7 +464,7 @@ cfg.CreateMap&lt;PriceEntity, Money&gt;();
         <li><strong>Non-nullable value types</strong> (<code>int</code>, <code>bool</code>, etc.) — always copied (no sentinel for "not set")</li>
       </ul>
 
-      <pre><code>cfg.CreateMap&lt;UpdateOrderRequest, Order&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;UpdateOrderRequest, Order&gt;();
 
 var existing = db.Orders.Find(id)!;
 mapper.Patch(request, existing);   // only non-null fields overwrite existing
@@ -473,7 +474,7 @@ db.SaveChanges();</code></pre>
 
       <h3>Real-world example: PATCH endpoint</h3>
 
-      <pre><code>public class UpdateProductRequest
+      <pre><code class="language-csharp">public class UpdateProductRequest
 {
     public string? Name { get; set; }
     public decimal? Price { get; set; }
@@ -503,7 +504,7 @@ app.MapPatch("/products/{id}", async (int id, UpdateProductRequest req, AppDbCon
 
       <p>Add post-mapping validation rules directly to a type map with <code>.Validate()</code>. All rules run after mapping completes; a <code>MappingValidationException</code> is thrown that contains <strong>every</strong> violation (not just the first):</p>
 
-      <pre><code>cfg.CreateMap&lt;CreateOrderRequest, Order&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;CreateOrderRequest, Order&gt;()
     .Validate(d =&gt; d.CustomerName, n =&gt; !string.IsNullOrWhiteSpace(n), "Customer name is required")
     .Validate(d =&gt; d.Total, t =&gt; t &gt; 0, "Order total must be positive")
     .Validate(d =&gt; d.Lines, l =&gt; l.Count &gt; 0, "Order must have at least one line");</code></pre>
@@ -521,7 +522,7 @@ catch (MappingValidationException ex)
 
       <h3>Use in a minimal API endpoint</h3>
 
-      <pre><code>app.MapPost("/orders", (CreateOrderRequest req, IMapper mapper, AppDbContext db) =&gt;
+      <pre><code class="language-csharp">app.MapPost("/orders", (CreateOrderRequest req, IMapper mapper, AppDbContext db) =&gt;
 {
     try
     {
@@ -548,7 +549,7 @@ catch (MappingValidationException ex)
 
       <p><code>ProjectTo&lt;TSource, TDest&gt;(config)</code> builds a pure <code>Expression&lt;Func&lt;TSource, TDest&gt;&gt;</code> from the registered type map and passes it directly to <code>IQueryable.Select()</code>. The expression is <strong>never compiled</strong> by EggMapper, so LINQ providers (EF Core, etc.) can translate it to SQL.</p>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;();
 
 // EF Core — translated to SQL SELECT
 var dtos = await dbContext.Orders
@@ -567,7 +568,7 @@ var dtos = await dbContext.Orders
 
       <h3>Complex query with ProjectTo</h3>
 
-      <pre><code>// Paginated order list with filtering
+      <pre><code class="language-csharp">// Paginated order list with filtering
 var page = await dbContext.Orders
     .Where(o =&gt; o.CustomerId == customerId)
     .Where(o =&gt; o.Status != OrderStatus.Cancelled)
@@ -579,7 +580,7 @@ var page = await dbContext.Orders
 
       <h3>ProjectTo with nested maps</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDetailDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDetailDto&gt;();
 cfg.CreateMap&lt;Customer, CustomerBriefDto&gt;();
 cfg.CreateMap&lt;Address, AddressBriefDto&gt;();
 
@@ -607,7 +608,7 @@ var combined = dbContext.Orders
 
       <p>Map generic wrapper types without registering every closed variant:</p>
 
-      <pre><code>// Generic wrapper types
+      <pre><code class="language-csharp">// Generic wrapper types
 public class Result&lt;T&gt;
 {
     public bool Success { get; set; }
@@ -632,7 +633,7 @@ var dto = mapper.Map&lt;Result&lt;Order&gt;, ResultDto&lt;OrderDto&gt;&gt;(order
 
       <h3>Real-world example: paginated API responses</h3>
 
-      <pre><code>public class PagedResult&lt;T&gt;
+      <pre><code class="language-csharp">public class PagedResult&lt;T&gt;
 {
     public List&lt;T&gt; Items { get; set; } = [];
     public int TotalCount { get; set; }
@@ -660,7 +661,7 @@ var dto = mapper.Map&lt;PagedResult&lt;Product&gt;, PagedResultDto&lt;ProductDto
 
       <p>Map an object to the same type without any configuration:</p>
 
-      <pre><code>// No CreateMap&lt;Customer, Customer&gt;() needed
+      <pre><code class="language-csharp">// No CreateMap&lt;Customer, Customer&gt;() needed
 var copy = mapper.Map&lt;Customer, Customer&gt;(customer);</code></pre>
 
       <p>This is useful for creating snapshots before mutation, or for detaching EF Core tracked entities.</p>
@@ -687,7 +688,7 @@ if (before.Status != order.Status)
 
       <h3>Recommended: validate in a unit test</h3>
 
-      <pre><code>[Fact]
+      <pre><code class="language-csharp">[Fact]
 public void AllMappings_ShouldBeValid()
 {
     var config = new MapperConfiguration(cfg =&gt;
@@ -723,5 +724,7 @@ public void AllMappings_ShouldBeValid()
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Configuration.html
+++ b/docs/Configuration.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper configuration — MapperConfiguration, CreateMap, validation, thread safety.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -59,7 +60,7 @@
 
       <p><code>MapperConfiguration</code> is the <strong>entry point</strong> for EggMapper. You construct it once (typically at startup) and keep a single instance for the lifetime of the application.</p>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 var config = new MapperConfiguration(cfg =&gt;
 {
@@ -75,25 +76,25 @@ var config = new MapperConfiguration(cfg =&gt;
 
       <h3>Basic map</h3>
 
-      <pre><code>cfg.CreateMap&lt;Source, Destination&gt;();</code></pre>
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Source, Destination&gt;();</code></pre>
 
       <p>By convention, properties with identical names (case-insensitive) are mapped automatically. No configuration needed for matching property names.</p>
 
       <h3>With custom member mapping</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;()
     .ForMember(d =&gt; d.CustomerName, o =&gt; o.MapFrom(s =&gt; s.Customer.FullName))
     .ForMember(d =&gt; d.TotalWithTax, o =&gt; o.MapFrom(s =&gt; s.Total * 1.1m))
     .ForMember(d =&gt; d.InternalNotes, o =&gt; o.Ignore());</code></pre>
 
       <h3>Reverse map</h3>
 
-      <pre><code>cfg.CreateMap&lt;Source, Destination&gt;().ReverseMap();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Source, Destination&gt;().ReverseMap();
 // Registers both Source -&gt; Destination and Destination -&gt; Source</code></pre>
 
       <h3>Multiple maps</h3>
 
-      <pre><code>cfg.CreateMap&lt;Customer, CustomerDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Customer, CustomerDto&gt;();
 cfg.CreateMap&lt;Customer, CustomerSummaryDto&gt;();
 cfg.CreateMap&lt;Address,  AddressDto&gt;();
 cfg.CreateMap&lt;Order,    OrderDto&gt;();
@@ -101,7 +102,7 @@ cfg.CreateMap&lt;Order,    OrderSummaryDto&gt;();</code></pre>
 
       <h3>Open generic maps</h3>
 
-      <pre><code>cfg.CreateMap(typeof(Result&lt;&gt;), typeof(ResultDto&lt;&gt;));
+      <pre><code class="language-csharp">cfg.CreateMap(typeof(Result&lt;&gt;), typeof(ResultDto&lt;&gt;));
 cfg.CreateMap(typeof(PagedList&lt;&gt;), typeof(PagedListDto&lt;&gt;));</code></pre>
 
       <hr>
@@ -123,7 +124,7 @@ cfg.AddProfile&lt;CustomerProfile&gt;();</code></pre>
 
       <h2>Creating a Mapper</h2>
 
-      <pre><code>IMapper mapper = config.CreateMapper();</code></pre>
+      <pre><code class="language-csharp">IMapper mapper = config.CreateMapper();</code></pre>
 
       <p><code>CreateMapper()</code> returns a lightweight <code>IMapper</code> instance backed by the compiled delegate cache. You may call it multiple times; each call returns a new wrapper around the same shared cache.</p>
 
@@ -157,7 +158,7 @@ config.AssertConfigurationIsValid();</code></pre>
 
       <h3>Recommended: validate in a unit test</h3>
 
-      <pre><code>[Fact]
+      <pre><code class="language-csharp">[Fact]
 public void AllMappings_ShouldBeValid()
 {
     var config = new MapperConfiguration(cfg =&gt;
@@ -187,7 +188,7 @@ public void AllMappings_ShouldBeValid()
 
       <h3>Small application — inline configuration</h3>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.CreateMap&lt;Product, ProductDto&gt;();
     cfg.CreateMap&lt;Order, OrderDto&gt;()
@@ -196,7 +197,7 @@ public void AllMappings_ShouldBeValid()
 
       <h3>Medium application — profiles</h3>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.AddProfile&lt;OrderProfile&gt;();
     cfg.AddProfile&lt;CustomerProfile&gt;();
@@ -205,14 +206,14 @@ public void AllMappings_ShouldBeValid()
 
       <h3>Large application — assembly scanning</h3>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
     cfg.AddProfiles(
         typeof(OrderProfile).Assembly,        // Core domain
         typeof(ReportProfile).Assembly));     // Reporting module</code></pre>
 
       <h3>Multi-module application</h3>
 
-      <pre><code>// Each module defines its own profiles
+      <pre><code class="language-csharp">// Each module defines its own profiles
 builder.Services.AddEggMapper(
     typeof(OrderModule.OrderProfile).Assembly,
     typeof(InventoryModule.ProductProfile).Assembly,
@@ -261,5 +262,7 @@ builder.Services.AddEggMapper(
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Dependency-Injection.html
+++ b/docs/Dependency-Injection.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper DI integration — ASP.NET Core, Blazor, gRPC, Worker Service, minimal API setup.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -59,7 +60,7 @@
 
       <h2>Installation</h2>
 
-      <pre><code>dotnet add package EggMapper</code></pre>
+      <pre><code class="language-bash">dotnet add package EggMapper</code></pre>
 
       <hr>
 
@@ -67,7 +68,7 @@
 
       <h3>Minimal API</h3>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -119,7 +120,7 @@ app.Run();</code></pre>
 
       <h3>MVC Controller</h3>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 using EggMapper;
 
 builder.Services.AddControllers();
@@ -166,7 +167,7 @@ public class OrdersController(IMapper mapper, AppDbContext db) : ControllerBase
 
       <h2>Blazor Server / InteractiveServer</h2>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 using EggMapper;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -175,7 +176,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddEggMapper(typeof(ProductProfile).Assembly);</code></pre>
 
-      <pre><code>@* Components/Pages/Products.razor *@
+      <pre><code class="language-csharp">@* Components/Pages/Products.razor *@
 @page "/products"
 @inject IMapper Mapper
 @inject AppDbContext DbContext
@@ -204,7 +205,7 @@ builder.Services.AddEggMapper(typeof(ProductProfile).Assembly);</code></pre>
 
       <h2>Blazor WebAssembly (WASM)</h2>
 
-      <pre><code>// Program.cs (client-side)
+      <pre><code class="language-csharp">// Program.cs (client-side)
 using EggMapper;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -216,7 +217,7 @@ builder.Services.AddEggMapper(typeof(ProductProfile).Assembly);
 
 await builder.Build().RunAsync();</code></pre>
 
-      <pre><code>// Services/ProductService.cs
+      <pre><code class="language-csharp">// Services/ProductService.cs
 public class ProductService(HttpClient http, IMapper mapper)
 {
     public async Task&lt;List&lt;ProductViewModel&gt;&gt; GetProductsAsync()
@@ -237,7 +238,7 @@ public class ProductService(HttpClient http, IMapper mapper)
 
       <h2>gRPC Service</h2>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 using EggMapper;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -248,7 +249,7 @@ var app = builder.Build();
 app.MapGrpcService&lt;OrderGrpcService&gt;();
 app.Run();</code></pre>
 
-      <pre><code>// Services/OrderGrpcService.cs
+      <pre><code class="language-csharp">// Services/OrderGrpcService.cs
 public class OrderGrpcService(IMapper mapper, AppDbContext db)
     : OrderService.OrderServiceBase
 {
@@ -284,7 +285,7 @@ public class OrderGrpcService(IMapper mapper, AppDbContext db)
 
       <h2>Worker Service / Background Service</h2>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 using EggMapper;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -296,7 +297,7 @@ builder.Services.AddHostedService&lt;DataSyncWorker&gt;();
 var host = builder.Build();
 host.Run();</code></pre>
 
-      <pre><code>// Workers/DataSyncWorker.cs
+      <pre><code class="language-csharp">// Workers/DataSyncWorker.cs
 public class DataSyncWorker(
     IMapper mapper,
     IServiceScopeFactory scopeFactory,
@@ -327,19 +328,19 @@ public class DataSyncWorker(
 
       <h3>Scan an assembly for Profiles (recommended)</h3>
 
-      <pre><code>builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
+      <pre><code class="language-csharp">builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
 
       <p>Pass one or more assemblies and every <code>Profile</code> subclass found will be registered automatically.</p>
 
       <h3>Scan multiple assemblies</h3>
 
-      <pre><code>builder.Services.AddEggMapper(
+      <pre><code class="language-csharp">builder.Services.AddEggMapper(
     typeof(OrderProfile).Assembly,    // Web layer profiles
     typeof(ReportProfile).Assembly);  // Reporting layer profiles</code></pre>
 
       <h3>Inline configuration (no profiles needed)</h3>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 builder.Services.AddEggMapper(cfg =&gt;
 {
@@ -372,7 +373,7 @@ builder.Services.AddEggMapper(cfg =&gt;
 
       <h3>With primary constructors (C# 12)</h3>
 
-      <pre><code>public class OrderService(IMapper mapper, AppDbContext db)
+      <pre><code class="language-csharp">public class OrderService(IMapper mapper, AppDbContext db)
 {
     public OrderDto GetOrder(int id)
     {
@@ -383,7 +384,7 @@ builder.Services.AddEggMapper(cfg =&gt;
 
       <h3>Traditional constructor injection</h3>
 
-      <pre><code>public class OrderService
+      <pre><code class="language-csharp">public class OrderService
 {
     private readonly IMapper _mapper;
     private readonly AppDbContext _db;
@@ -405,7 +406,7 @@ builder.Services.AddEggMapper(cfg =&gt;
 
       <p>You can also inject <code>MapperConfiguration</code> for <code>ProjectTo</code> or <code>BuildProjection</code>:</p>
 
-      <pre><code>public class ProductQueryService(MapperConfiguration config, AppDbContext db)
+      <pre><code class="language-csharp">public class ProductQueryService(MapperConfiguration config, AppDbContext db)
 {
     public async Task&lt;List&lt;ProductDto&gt;&gt; GetActiveProductsAsync()
     {
@@ -422,7 +423,7 @@ builder.Services.AddEggMapper(cfg =&gt;
 
       <p>Use <code>ServiceCollection</code> directly in unit tests without a full host:</p>
 
-      <pre><code>[Fact]
+      <pre><code class="language-csharp">[Fact]
 public void Should_MapOrderToDto()
 {
     var services = new ServiceCollection();
@@ -452,7 +453,7 @@ public void Should_MapOrderToDto()
 
       <h3>Validate all mappings in a single test</h3>
 
-      <pre><code>[Fact]
+      <pre><code class="language-csharp">[Fact]
 public void AllMappings_ShouldBeValid()
 {
     var services = new ServiceCollection();
@@ -489,5 +490,7 @@ public void AllMappings_ShouldBeValid()
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Getting-Started.html
+++ b/docs/Getting-Started.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Getting started with EggMapper — install, define types, configure, map.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -59,11 +60,11 @@
 
       <h3>.NET CLI</h3>
 
-      <pre><code>dotnet add package EggMapper</code></pre>
+      <pre><code class="language-bash">dotnet add package EggMapper</code></pre>
 
       <h3>Package Manager Console (Visual Studio)</h3>
 
-      <pre><code>Install-Package EggMapper</code></pre>
+      <pre><code class="language-powershell">Install-Package EggMapper</code></pre>
 
       <div class="note"><p>DI support (<code>AddEggMapper()</code>) is included in the main package. No separate package needed.</p></div>
 
@@ -73,7 +74,7 @@
 
       <h3>1 -- Define your types</h3>
 
-      <pre><code>public class Order
+      <pre><code class="language-csharp">public class Order
 {
     public int Id { get; set; }
     public string CustomerName { get; set; } = "";
@@ -91,7 +92,7 @@ public class OrderDto
 
       <h3>2 -- Create a configuration</h3>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 var config = new MapperConfiguration(cfg =&gt;
 {
@@ -102,7 +103,7 @@ var config = new MapperConfiguration(cfg =&gt;
 
       <h3>3 -- Create a mapper and map</h3>
 
-      <pre><code>IMapper mapper = config.CreateMapper();
+      <pre><code class="language-csharp">IMapper mapper = config.CreateMapper();
 
 var order = new Order
 {
@@ -128,7 +129,7 @@ OrderDto dto2 = mapper.Map&lt;OrderDto&gt;(order);</code></pre>
 
       <p>When property names differ between source and destination, use <code>ForMember</code>:</p>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.CreateMap&lt;Customer, CustomerDto&gt;()
         .ForMember(d =&gt; d.FullName,
@@ -162,21 +163,21 @@ await db.SaveChangesAsync();</code></pre>
 
       <h3>Using <code>MapList</code> (recommended for performance)</h3>
 
-      <pre><code>List&lt;Order&gt; orders = await db.Orders.ToListAsync();
+      <pre><code class="language-csharp">List&lt;Order&gt; orders = await db.Orders.ToListAsync();
 
 // Fully inlined compiled loop — near-manual speed
 List&lt;OrderDto&gt; dtos = mapper.MapList&lt;Order, OrderDto&gt;(orders);</code></pre>
 
       <h3>Using <code>Map</code> with collection types</h3>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;();
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;();
 
 // Auto-detects collection types
 var dtos = mapper.Map&lt;List&lt;OrderDto&gt;&gt;(orders);</code></pre>
 
       <h3>Nested collections</h3>
 
-      <pre><code>// Customer has List&lt;Order&gt;, Order has List&lt;OrderLine&gt;
+      <pre><code class="language-csharp">// Customer has List&lt;Order&gt;, Order has List&lt;OrderLine&gt;
 cfg.CreateMap&lt;Customer, CustomerDto&gt;();
 cfg.CreateMap&lt;Order, OrderDto&gt;();
 cfg.CreateMap&lt;OrderLine, OrderLineDto&gt;();
@@ -191,14 +192,14 @@ var dto = mapper.Map&lt;Customer, CustomerDto&gt;(customer);
 
       <p>EggMapper automatically selects the best-matching constructor:</p>
 
-      <pre><code>public record OrderDto(int Id, string CustomerName, decimal Total);
+      <pre><code class="language-csharp">public record OrderDto(int Id, string CustomerName, decimal Total);
 
 cfg.CreateMap&lt;Order, OrderDto&gt;();
 // Calls: new OrderDto(src.Id, src.CustomerName, src.Total)</code></pre>
 
       <p>Records with additional init properties:</p>
 
-      <pre><code>public record ProductDto(int Id, string Name)
+      <pre><code class="language-csharp">public record ProductDto(int Id, string Name)
 {
     public decimal Price { get; init; }
     public bool InStock { get; init; }
@@ -211,7 +212,7 @@ cfg.CreateMap&lt;Product, ProductDto&gt;();
 
       <h2>Using with DI (ASP.NET Core)</h2>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);
 
 // Any service or controller
@@ -268,5 +269,7 @@ public class OrderService(IMapper mapper, AppDbContext db)
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Migration-Guide.html
+++ b/docs/Migration-Guide.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Migrate from AutoMapper to EggMapper, or from runtime to compile-time mapping tiers.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -63,23 +64,23 @@
 
       <p><strong>1. Swap NuGet packages:</strong></p>
 
-      <pre><code>dotnet remove package AutoMapper
+      <pre><code class="language-bash">dotnet remove package AutoMapper
 dotnet remove package AutoMapper.Extensions.Microsoft.DependencyInjection
 dotnet add package EggMapper</code></pre>
 
       <p><strong>2. Find and replace the namespace:</strong></p>
 
-      <pre><code>- using AutoMapper;
+      <pre><code class="language-csharp">- using AutoMapper;
 + using EggMapper;</code></pre>
 
       <p><strong>3. Update DI registration:</strong></p>
 
-      <pre><code>- services.AddAutoMapper(typeof(MyProfile).Assembly);
+      <pre><code class="language-csharp">- services.AddAutoMapper(typeof(MyProfile).Assembly);
 + services.AddEggMapper(typeof(MyProfile).Assembly);</code></pre>
 
       <p><strong>4. Update ProjectTo calls (if any):</strong></p>
 
-      <pre><code>- query.ProjectTo&lt;ProductDto&gt;(config);
+      <pre><code class="language-csharp">- query.ProjectTo&lt;ProductDto&gt;(config);
 + query.ProjectTo&lt;Product, ProductDto&gt;(config);</code></pre>
 
       <p><strong>5. Run tests.</strong> All your existing <code>CreateMap</code>, <code>ForMember</code>, <code>Profile</code>, and <code>IMapper</code> code works unchanged.</p>
@@ -124,7 +125,7 @@ dotnet add package EggMapper</code></pre>
 
       <p><strong>Before (AutoMapper):</strong></p>
 
-      <pre><code>using AutoMapper;
+      <pre><code class="language-csharp">using AutoMapper;
 
 public class OrdersController(IMapper mapper, AppDbContext db) : ControllerBase
 {
@@ -145,7 +146,7 @@ public class OrdersController(IMapper mapper, AppDbContext db) : ControllerBase
 
       <p><strong>After (EggMapper):</strong></p>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 public class OrdersController(IMapper mapper, AppDbContext db) : ControllerBase
 {
@@ -170,7 +171,7 @@ public class OrdersController(IMapper mapper, AppDbContext db) : ControllerBase
 
       <p>If you had self-referencing maps for cloning, EggMapper handles these automatically:</p>
 
-      <pre><code>  // Before
+      <pre><code class="language-csharp">  // Before
   cfg.CreateMap&lt;Product, Product&gt;();
 
   // After — remove the line, it auto-compiles</code></pre>
@@ -200,7 +201,7 @@ public class OrdersController(IMapper mapper, AppDbContext db) : ControllerBase
 
       <h4>Before (runtime)</h4>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.CreateMap&lt;Order, OrderDto&gt;();
 });
@@ -211,7 +212,7 @@ var dto = mapper.Map&lt;OrderDto&gt;(order);</code></pre>
 
       <h4>After (Tier 2 -- compile-time extension method)</h4>
 
-      <pre><code>// 1. Add [MapTo] to the source class
+      <pre><code class="language-csharp">// 1. Add [MapTo] to the source class
 [MapTo(typeof(OrderDto))]
 public class Order
 {
@@ -235,13 +236,13 @@ var dto = order.ToOrderDto();</code></pre>
 
       <h4>Before (runtime with customization)</h4>
 
-      <pre><code>cfg.CreateMap&lt;Customer, CustomerDto&gt;()
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Customer, CustomerDto&gt;()
    .ForMember(d =&gt; d.DisplayLabel,
               o =&gt; o.MapFrom(s =&gt; $"{s.FirstName} {s.LastName}"));</code></pre>
 
       <h4>After (Tier 3 -- partial class mapper)</h4>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class CustomerMapper
 {
     public partial CustomerDto Map(Customer source);
@@ -259,11 +260,11 @@ public partial class CustomerMapper
 
       <h4>Before (runtime)</h4>
 
-      <pre><code>cfg.CreateMap&lt;Order, OrderDto&gt;().ReverseMap();</code></pre>
+      <pre><code class="language-csharp">cfg.CreateMap&lt;Order, OrderDto&gt;().ReverseMap();</code></pre>
 
       <h4>After (Tier 3)</h4>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto Map(Order source);
@@ -276,7 +277,7 @@ public partial class OrderMapper
 
       <p>If you have a large <code>Profile</code> subclass, the Analyzer EGG1003 will flag each bare <code>CreateMap&lt;S,D&gt;()</code> call that has no customizations and suggest replacing it with <code>[MapTo]</code>. Use the IDE quick-fix to apply the suggestion automatically.</p>
 
-      <pre><code>// EGG1003 (Info): CreateMap&lt;Order, OrderDto&gt;() has no customizations.
+      <pre><code class="language-csharp">// EGG1003 (Info): CreateMap&lt;Order, OrderDto&gt;() has no customizations.
 // Consider using [MapTo(typeof(OrderDto))] on Order with EggMapper.Generator
 // for compile-time type safety and zero-overhead mapping.</code></pre>
 
@@ -328,5 +329,7 @@ public partial class OrderMapper
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Performance.html
+++ b/docs/Performance.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper performance — benchmarks, allocation analysis, optimization techniques, and tuning tips.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -113,7 +114,7 @@ dst.Address = new AddressDto {
 
       <h3>3. Static Generic Caching</h3>
 
-<pre><code>// EggMapper: zero-cost lookup via static generic class
+<pre><code class="language-csharp">// EggMapper: zero-cost lookup via static generic class
 static class FastCache&lt;TSource, TDestination&gt;
 {
     public static volatile CacheEntry? Entry;
@@ -180,7 +181,7 @@ static class FastCache&lt;TSource, TDestination&gt;
 
       <h2>Running Benchmarks Locally</h2>
 
-<pre><code>cd src/EggMapper.Benchmarks
+<pre><code class="language-bash">cd src/EggMapper.Benchmarks
 
 # All benchmarks on .NET 10 (recommended)
 dotnet run -c Release -f net10.0 -- --filter '*'
@@ -249,7 +250,7 @@ var dto = mapper.Map&lt;OrderDto&gt;((object)order);</code></pre>
 
       <h3>Use <code>MapList&lt;TSrc, TDst&gt;()</code> for Collections</h3>
 
-<pre><code>// Fast: fully inlined compiled loop
+<pre><code class="language-csharp">// Fast: fully inlined compiled loop
 List&lt;OrderDto&gt; dtos = mapper.MapList&lt;Order, OrderDto&gt;(orders);
 
 // Slower: per-element delegate invocation
@@ -261,7 +262,7 @@ var dtos = orders.Select(o =&gt; mapper.Map&lt;Order, OrderDto&gt;(o)).ToList();
 
       <div class="note"><p><code>ProjectTo</code> pushes the mapping into the SQL query. Only the columns needed for the DTO are selected, with no entity tracking overhead. Always prefer it for read-only data.</p></div>
 
-<pre><code>using EggMapper;
+<pre><code class="language-csharp">using EggMapper;
 
 // Best: SQL does the projection, no entity materialization
 var dtos = await db.Orders
@@ -280,7 +281,7 @@ var dtos = mapper.MapList&lt;Order, OrderDto&gt;(entities);</code></pre>
 
       <h3>Validate in Tests</h3>
 
-<pre><code>// In a unit test
+<pre><code class="language-csharp">// In a unit test
 [Fact]
 public void MappingConfiguration_IsValid()
 {
@@ -305,5 +306,7 @@ public void MappingConfiguration_IsValid()
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Profiles.html
+++ b/docs/Profiles.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper profiles — group related mappings into reusable Profile classes.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -63,7 +64,7 @@
 
       <p>Inherit from <code>EggMapper.Profile</code> and call <code>CreateMap</code> inside the constructor:</p>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 public class OrderProfile : Profile
 {
@@ -83,12 +84,12 @@ public class OrderProfile : Profile
 
       <h3>Single profile</h3>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
     cfg.AddProfile&lt;OrderProfile&gt;());</code></pre>
 
       <h3>Multiple profiles</h3>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.AddProfile&lt;OrderProfile&gt;();
     cfg.AddProfile&lt;CustomerProfile&gt;();
@@ -97,7 +98,7 @@ public class OrderProfile : Profile
 
       <h3>Scan an assembly (recommended for large projects)</h3>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
     cfg.AddProfiles(typeof(OrderProfile).Assembly));</code></pre>
 
       <p>All classes that inherit <code>Profile</code> in the provided assembly are discovered and registered automatically.</p>
@@ -108,7 +109,7 @@ public class OrderProfile : Profile
 
       <p>When using the DI integration, pass the assembly directly:</p>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
 
       <p>See <a href="Dependency-Injection.html">Dependency Injection</a> for details.</p>
@@ -119,7 +120,7 @@ builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
 
       <h3>E-commerce order aggregate</h3>
 
-      <pre><code>public class OrderProfile : Profile
+      <pre><code class="language-csharp">public class OrderProfile : Profile
 {
     public OrderProfile()
     {
@@ -152,7 +153,7 @@ builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
 
       <h3>Customer aggregate with address</h3>
 
-      <pre><code>public class CustomerProfile : Profile
+      <pre><code class="language-csharp">public class CustomerProfile : Profile
 {
     public CustomerProfile()
     {
@@ -178,7 +179,7 @@ builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
 
       <h3>Product catalog with categories</h3>
 
-      <pre><code>public class ProductProfile : Profile
+      <pre><code class="language-csharp">public class ProductProfile : Profile
 {
     public ProductProfile()
     {
@@ -280,5 +281,7 @@ builder.Services.AddEggMapper(typeof(OrderProfile).Assembly);</code></pre>
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Tier2-Getting-Started.html
+++ b/docs/Tier2-Getting-Started.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper.Generator — compile-time extension methods with [MapTo] attribute.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -61,7 +62,7 @@
 
       <h2>Installation</h2>
 
-      <pre><code>dotnet add package EggMapper.Generator</code></pre>
+      <pre><code class="language-bash">dotnet add package EggMapper.Generator</code></pre>
 
       <blockquote><p>The generator package automatically injects the <code>[MapTo]</code>, <code>[MapProperty]</code>, and <code>[MapIgnore]</code> attributes into your compilation — no separate abstractions package needed.</p></blockquote>
 
@@ -71,7 +72,7 @@
 
       <h3>1 — Annotate the source class</h3>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 [MapTo(typeof(OrderDto))]
 public class Order
@@ -102,7 +103,7 @@ List&lt;OrderDto&gt; dtos = orders.ToOrderDtoList();   // generated list method<
 
       <p>Apply <code>[MapTo]</code> multiple times to map a single source to several destinations:</p>
 
-      <pre><code>[MapTo(typeof(OrderDto))]
+      <pre><code class="language-csharp">[MapTo(typeof(OrderDto))]
 [MapTo(typeof(OrderSummary))]
 public class Order { ... }</code></pre>
 
@@ -112,7 +113,7 @@ public class Order { ... }</code></pre>
 
       <h2>Renaming Properties (<code>[MapProperty]</code>)</h2>
 
-      <pre><code>[MapTo(typeof(CustomerDto))]
+      <pre><code class="language-csharp">[MapTo(typeof(CustomerDto))]
 public class Customer
 {
     public int    Id   { get; set; }
@@ -125,7 +126,7 @@ public class Customer
 
       <h2>Ignoring Properties (<code>[MapIgnore]</code>)</h2>
 
-      <pre><code>[MapTo(typeof(CustomerDto))]
+      <pre><code class="language-csharp">[MapTo(typeof(CustomerDto))]
 public class Customer
 {
     public int    Id       { get; set; }
@@ -141,7 +142,7 @@ public class Customer
 
       <p>Declare a partial static method to run custom logic after the generated initializer:</p>
 
-      <pre><code>// In a separate file (user-authored):
+      <pre><code class="language-csharp">// In a separate file (user-authored):
 public static partial class OrderToOrderDtoExtensions
 {
     static partial void AfterMap(Order source, OrderDto dest)
@@ -191,5 +192,7 @@ public static partial class OrderToOrderDtoExtensions
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/Tier3-Getting-Started.html
+++ b/docs/Tier3-Getting-Started.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper.ClassMapper — partial class mapper generation with [EggMapper] attribute.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -61,7 +62,7 @@
 
       <h2>Installation</h2>
 
-      <pre><code>dotnet add package EggMapper.ClassMapper</code></pre>
+      <pre><code class="language-bash">dotnet add package EggMapper.ClassMapper</code></pre>
 
       <hr>
 
@@ -69,7 +70,7 @@
 
       <h3>1 — Declare a partial mapper class</h3>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 [EggMapper]
 public partial class OrderMapper
@@ -79,7 +80,7 @@ public partial class OrderMapper
 
       <h3>2 — The generator produces the implementation</h3>
 
-      <pre><code>// Auto-generated (OrderMapper.g.cs):
+      <pre><code class="language-csharp">// Auto-generated (OrderMapper.g.cs):
 public partial class OrderMapper
 {
     public static OrderMapper Instance { get; } = new OrderMapper();
@@ -112,7 +113,7 @@ OrderDto dto = mapper.Map(order);</code></pre>
 
       <p>Declare both directions and the generator implements both:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto Map(Order source);
@@ -125,7 +126,7 @@ public partial class OrderMapper
 
       <p>Declare a method for each nested type — the generator chains them automatically:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto    Map(Order source);
@@ -140,7 +141,7 @@ public partial class OrderMapper
 
       <p>If a destination property is <code>List&lt;TDst&gt;</code> and source is a list-like type, and you have a partial method that maps <code>TSrc → TDst</code>:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto Map(Order source);       // Order.Lines → OrderDto.Lines
@@ -154,7 +155,7 @@ public partial class OrderMapper
 
       <p>Add non-partial methods to the mapper class — the generator detects them by signature and uses them automatically:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class PersonMapper
 {
     public partial PersonDto Map(Person source);
@@ -169,7 +170,7 @@ public partial class PersonMapper
 
       <p>Enum-to-enum properties are mapped with an explicit cast. If underlying types differ, EGG3003 (Info) is reported.</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class StatusMapper
 {
     public partial StatusDto Map(Status source);
@@ -218,5 +219,7 @@ public partial class StatusMapper
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/assets/css/eggspot.css
+++ b/docs/assets/css/eggspot.css
@@ -187,7 +187,8 @@ pre {
 }
 pre code {
   background: none; border: none; padding: 0;
-  color: var(--text); font-size: inherit; white-space: pre;
+  font-size: inherit; white-space: pre;
+  /* colour controlled by prism-eggspot.css tokens */
 }
 
 /* ── Tables ──────────────────────────────────── */

--- a/docs/assets/css/prism-eggspot.css
+++ b/docs/assets/css/prism-eggspot.css
@@ -1,0 +1,88 @@
+/* ================================================================
+   Prism.js syntax theme — eggspot.app brand colours
+   #FAB400 yellow · #5956E9 purple · #FAB8C4 pink · dark bg
+   ================================================================ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #e2e2ef;
+  background: none;
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+  font-size: 0.875rem;
+  line-height: 1.65;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  tab-size: 2;
+  hyphens: none;
+}
+
+/* Comments */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #525270;
+  font-style: italic;
+}
+
+/* Punctuation */
+.token.punctuation { color: #6868a0; }
+
+/* Namespace */
+.token.namespace { opacity: 0.75; }
+
+/* Numbers, booleans, constants */
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted { color: #f08d49; }
+
+/* Strings, chars */
+.token.string,
+.token.char,
+.token.inserted { color: #7ec699; }
+
+/* Keywords */
+.token.keyword,
+.token.atrule { color: #7b9eff; }
+
+/* Operators */
+.token.operator,
+.token.entity { color: #8888b0; }
+
+/* Class names, types — eggspot yellow */
+.token.class-name,
+.token.type-list,
+.token.builtin,
+.token.tag { color: #FAB400; }
+
+/* Functions */
+.token.function,
+.token.function-definition { color: #61afef; }
+
+/* Attributes, properties */
+.token.attr-name,
+.token.attr-value,
+.token.property { color: #c0beff; }
+
+/* Decorators / annotations — eggspot pink */
+.token.decorator,
+.token.annotation,
+.token.variable,
+.token.regex,
+.token.important { color: #FAB8C4; }
+
+/* Selector, url */
+.token.selector,
+.token.url { color: #7ec699; }
+
+/* Bold / italic markers */
+.token.important,
+.token.bold { font-weight: 700; }
+.token.italic { font-style: italic; }
+
+/* Inline entity links */
+.token.entity { cursor: help; }

--- a/docs/diagnostics/EGG1002.html
+++ b/docs/diagnostics/EGG1002.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG1002: MapperConfiguration missing AssertConfigurationIsValid — EggMapper Analyzers warning.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -67,7 +68,7 @@
 
       <h2>Example (triggers warning)</h2>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.CreateMap&lt;Order, OrderDto&gt;();
 });
@@ -77,7 +78,7 @@
 
       <p>Call <code>AssertConfigurationIsValid()</code> at application startup — before serving any requests:</p>
 
-      <pre><code>var config = new MapperConfiguration(cfg =&gt;
+      <pre><code class="language-csharp">var config = new MapperConfiguration(cfg =&gt;
 {
     cfg.CreateMap&lt;Order, OrderDto&gt;();
 });
@@ -88,7 +89,7 @@ var mapper = config.CreateMapper();</code></pre>
 
       <h2>How to suppress</h2>
 
-      <pre><code>#pragma warning disable EGG1002
+      <pre><code class="language-csharp">#pragma warning disable EGG1002
 var config = new MapperConfiguration(...);
 #pragma warning restore EGG1002</code></pre>
 
@@ -106,5 +107,7 @@ var config = new MapperConfiguration(...);
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/diagnostics/EGG1003.html
+++ b/docs/diagnostics/EGG1003.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG1003: Consider compile-time mapping with [MapTo] — EggMapper Analyzers info.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -69,7 +70,7 @@
 
       <h2>Example (triggers info)</h2>
 
-      <pre><code>class MyProfile : Profile
+      <pre><code class="language-csharp">class MyProfile : Profile
 {
     public MyProfile()
     {
@@ -85,7 +86,7 @@
 
       <p>Install <code>EggMapper.Generator</code> and annotate the source class:</p>
 
-      <pre><code>[MapTo(typeof(OrderDto))]
+      <pre><code class="language-csharp">[MapTo(typeof(OrderDto))]
 public class Order { ... }
 
 // Usage:
@@ -95,7 +96,7 @@ var dto = order.ToOrderDto();</code></pre>
 
       <h2>How to suppress</h2>
 
-      <pre><code>#pragma warning disable EGG1003
+      <pre><code class="language-csharp">#pragma warning disable EGG1003
 CreateMap&lt;Order, OrderDto&gt;();
 #pragma warning restore EGG1003</code></pre>
 
@@ -113,5 +114,7 @@ CreateMap&lt;Order, OrderDto&gt;();
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/diagnostics/EGG2001.html
+++ b/docs/diagnostics/EGG2001.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG2001: Unmapped destination property (Generator) — EggMapper.Generator error.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -67,7 +68,7 @@
 
       <h2>Example (triggers error)</h2>
 
-      <pre><code>[MapTo(typeof(OrderDto))]
+      <pre><code class="language-csharp">[MapTo(typeof(OrderDto))]
 public class Order
 {
     public int Id { get; set; }
@@ -84,7 +85,7 @@ public class OrderDto
 
       <p><strong>Option A</strong> — Add the matching property to the source:</p>
 
-      <pre><code>public class Order
+      <pre><code class="language-csharp">public class Order
 {
     public int    Id    { get; set; }
     public string Label { get; set; } = "";
@@ -94,7 +95,7 @@ public class OrderDto
 
       <p>Not applicable when the property only exists on the destination. Use the <code>AfterMap</code> hook instead:</p>
 
-      <pre><code>public static partial class OrderToOrderDtoExtensions
+      <pre><code class="language-csharp">public static partial class OrderToOrderDtoExtensions
 {
     static partial void AfterMap(Order source, OrderDto dest)
     {
@@ -112,5 +113,7 @@ public class OrderDto
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/diagnostics/EGG2002.html
+++ b/docs/diagnostics/EGG2002.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG2002: Implicit type conversion applied (Generator) — EggMapper.Generator warning.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -67,7 +68,7 @@
 
       <h2>Example (triggers warning)</h2>
 
-      <pre><code>[MapTo(typeof(OrderDto))]
+      <pre><code class="language-csharp">[MapTo(typeof(OrderDto))]
 public class Order
 {
     public int Status { get; set; }   // int
@@ -84,7 +85,7 @@ public class OrderDto
 
       <h2>How to suppress</h2>
 
-      <pre><code>#pragma warning disable EGG2002
+      <pre><code class="language-csharp">#pragma warning disable EGG2002
 // ... your [MapTo]-annotated class
 #pragma warning restore EGG2002</code></pre>
     </div>
@@ -98,5 +99,7 @@ public class OrderDto
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/diagnostics/EGG3001.html
+++ b/docs/diagnostics/EGG3001.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG3001: Unmapped destination property (ClassMapper) — EggMapper.ClassMapper warning.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -67,7 +68,7 @@
 
       <h2>Example (triggers warning)</h2>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto Map(Order source);   // EGG3001: OrderDto.Label has no source
@@ -80,11 +81,11 @@ public class OrderDto{ public int Id { get; set; } public string Label { get; se
 
       <p><strong>Option A</strong> — Add a matching property to the source type:</p>
 
-      <pre><code>public class Order { public int Id { get; set; } public string Label { get; set; } = ""; }</code></pre>
+      <pre><code class="language-csharp">public class Order { public int Id { get; set; } public string Label { get; set; } = ""; }</code></pre>
 
       <p><strong>Option B</strong> — Add a custom converter method that provides the value:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto Map(Order source);
@@ -112,5 +113,7 @@ dotnet_diagnostic.EGG3001.severity = none</code></pre>
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/diagnostics/EGG3002.html
+++ b/docs/diagnostics/EGG3002.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG3002: No mapping methods declared (ClassMapper) — EggMapper.ClassMapper warning.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -67,7 +68,7 @@
 
       <h2>Example (triggers warning)</h2>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class EmptyMapper   // EGG3002: no partial mapping methods
 {
 }</code></pre>
@@ -76,7 +77,7 @@ public partial class EmptyMapper   // EGG3002: no partial mapping methods
 
       <p>Declare at least one <code>partial</code> mapping method:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class OrderMapper
 {
     public partial OrderDto Map(Order source);
@@ -99,5 +100,7 @@ public partial class OrderMapper
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/diagnostics/EGG3003.html
+++ b/docs/diagnostics/EGG3003.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EGG3003: Enum underlying type mismatch (ClassMapper) — EggMapper.ClassMapper info.">
   <link rel="icon" href="../favicon.ico">
   <link rel="stylesheet" href="../assets/css/eggspot.css">
+  <link rel="stylesheet" href="../assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -76,7 +77,7 @@ public enum DestStatus   : int   { Inactive = 0, Active = 1 }   // different ord
 
       <p>If the mapping is correct, suppress the diagnostic. If not, add a custom converter method:</p>
 
-      <pre><code>[EggMapper]
+      <pre><code class="language-csharp">[EggMapper]
 public partial class StatusMapper
 {
     public partial StatusDto Map(Status source);
@@ -104,5 +105,7 @@ dotnet_diagnostic.EGG3003.severity = none</code></pre>
   </div>
 </footer>
 <script src="../assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="EggMapper — the fastest .NET runtime object mapper. Drop-in AutoMapper replacement with the same API, 2–5× faster performance, and zero extra allocations.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -93,7 +94,7 @@
       </div>
 
       <h2>30-Second Quick Start</h2>
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 var config = new MapperConfiguration(cfg =&gt;
 {
@@ -182,5 +183,7 @@ var dto = mapper.Map&lt;CustomerDto&gt;(customer);</code></pre>
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/quick-start.html
+++ b/docs/quick-start.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Get started with EggMapper — installation, DI setup, profiles, collections, ProjectTo.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -57,7 +58,7 @@
 
       <h2>Installation</h2>
 
-      <pre><code>dotnet add package EggMapper</code></pre>
+      <pre><code class="language-bash">dotnet add package EggMapper</code></pre>
 
       <p>No separate DI package needed — <code>AddEggMapper()</code> is included.</p>
 
@@ -65,7 +66,7 @@
 
       <h2>Basic Usage</h2>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 // 1. Configure mappings
 var config = new MapperConfiguration(cfg =&gt;
@@ -83,7 +84,7 @@ var dto = mapper.Map&lt;ProductDto&gt;(product);</code></pre>
 
       <h2>Dependency Injection (ASP.NET Core)</h2>
 
-      <pre><code>// Program.cs
+      <pre><code class="language-csharp">// Program.cs
 using EggMapper;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -110,7 +111,7 @@ app.Run();</code></pre>
 
       <p>Group related maps into profile classes for organization:</p>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 public class OrderProfile : Profile
 {
@@ -141,7 +142,7 @@ public class CustomerProfile : Profile
 
       <h2>Collection Mapping</h2>
 
-      <pre><code>// Optimized batch mapping — fully inlined compiled loop
+      <pre><code class="language-csharp">// Optimized batch mapping — fully inlined compiled loop
 List&lt;ProductDto&gt; dtos = mapper.MapList&lt;Product, ProductDto&gt;(products);
 
 // Also works via Map&lt;&gt; — auto-detects collections
@@ -153,7 +154,7 @@ var dtos2 = mapper.Map&lt;List&lt;ProductDto&gt;&gt;(products);</code></pre>
 
       <h2>EF Core ProjectTo</h2>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 // Translates to SQL — no in-memory mapping, no entity materialization
 var dtos = await dbContext.Products
@@ -221,5 +222,7 @@ await db.SaveChangesAsync();</code></pre>
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>

--- a/docs/vs-automapper.html
+++ b/docs/vs-automapper.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Compare EggMapper and AutoMapper for .NET object mapping. Same API, 2-5x faster, MIT licensed.">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="assets/css/eggspot.css">
+  <link rel="stylesheet" href="assets/css/prism-eggspot.css">
 </head>
 <body>
 <header class="site-header">
@@ -133,25 +134,25 @@
 
       <h3>Step 1: Swap the NuGet Package</h3>
 
-      <pre><code>- dotnet add package AutoMapper
+      <pre><code class="language-bash">- dotnet add package AutoMapper
 - dotnet add package AutoMapper.Extensions.Microsoft.DependencyInjection
 + dotnet add package EggMapper</code></pre>
 
       <h3>Step 2: Find and Replace Namespace</h3>
 
-      <pre><code>- using AutoMapper;
+      <pre><code class="language-csharp">- using AutoMapper;
 + using EggMapper;</code></pre>
 
       <h3>Step 3: Update DI Registration</h3>
 
-      <pre><code>- services.AddAutoMapper(typeof(MyProfile).Assembly);
+      <pre><code class="language-csharp">- services.AddAutoMapper(typeof(MyProfile).Assembly);
 + services.AddEggMapper(typeof(MyProfile).Assembly);</code></pre>
 
       <h3>Step 4: Update ProjectTo Calls</h3>
 
       <p>EggMapper's <code>ProjectTo</code> takes both source and destination type parameters:</p>
 
-      <pre><code>- query.ProjectTo&lt;ProductDto&gt;(config);
+      <pre><code class="language-csharp">- query.ProjectTo&lt;ProductDto&gt;(config);
 + query.ProjectTo&lt;Product, ProductDto&gt;(config);</code></pre>
 
       <h3>Step 5: Run Tests</h3>
@@ -178,7 +179,7 @@
 
       <h3>ForMember with MapFrom</h3>
 
-      <pre><code>using EggMapper;
+      <pre><code class="language-csharp">using EggMapper;
 
 // Identical in both libraries
 cfg.CreateMap&lt;Customer, CustomerDto&gt;()
@@ -187,18 +188,18 @@ cfg.CreateMap&lt;Customer, CustomerDto&gt;()
 
       <h3>Ignore</h3>
 
-      <pre><code>// Identical in both libraries
+      <pre><code class="language-csharp">// Identical in both libraries
 cfg.CreateMap&lt;User, UserDto&gt;()
     .ForMember(d =&gt; d.PasswordHash, o =&gt; o.Ignore());</code></pre>
 
       <h3>ReverseMap</h3>
 
-      <pre><code>// Identical in both libraries
+      <pre><code class="language-csharp">// Identical in both libraries
 cfg.CreateMap&lt;Order, OrderDto&gt;().ReverseMap();</code></pre>
 
       <h3>Profile</h3>
 
-      <pre><code>// Identical in both libraries
+      <pre><code class="language-csharp">// Identical in both libraries
 public class OrderProfile : Profile
 {
     public OrderProfile()
@@ -210,20 +211,20 @@ public class OrderProfile : Profile
 
       <h3>Conditions</h3>
 
-      <pre><code>// Identical in both libraries
+      <pre><code class="language-csharp">// Identical in both libraries
 cfg.CreateMap&lt;Product, ProductDto&gt;()
     .ForMember(d =&gt; d.Price,
                o =&gt; o.Condition(s =&gt; s.Price &gt; 0));</code></pre>
 
       <h3>BeforeMap / AfterMap</h3>
 
-      <pre><code>// Identical in both libraries
+      <pre><code class="language-csharp">// Identical in both libraries
 cfg.CreateMap&lt;Order, OrderDto&gt;()
     .AfterMap((src, dst) =&gt; dst.MappedAt = DateTime.UtcNow);</code></pre>
 
       <h3>MaxDepth (self-referencing types)</h3>
 
-      <pre><code>// Identical in both libraries
+      <pre><code class="language-csharp">// Identical in both libraries
 cfg.CreateMap&lt;Category, CategoryDto&gt;()
     .MaxDepth(3);</code></pre>
 
@@ -240,7 +241,7 @@ cfg.CreateMap&lt;Category, CategoryDto&gt;()
 
       <h2>Ready to Migrate?</h2>
 
-      <pre><code>dotnet add package EggMapper</code></pre>
+      <pre><code class="language-bash">dotnet add package EggMapper</code></pre>
 
       <div class="note"><p>Most migrations are a find-and-replace. The entire process typically takes 5 minutes for a medium-sized project.</p></div>
 
@@ -259,5 +260,7 @@ cfg.CreateMap&lt;Category, CategoryDto&gt;()
   </div>
 </footer>
 <script src="assets/js/nav.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **`prism-eggspot.css`** — custom Prism.js dark theme using eggspot brand colours: `#FAB400` yellow for types/class names, `#7b9eff` blue for keywords, `#7ec699` green for strings, `#FAB8C4` pink for decorators/annotations, `#f08d49` orange for numbers
- **187 code blocks** tagged with `language-csharp`, `language-bash`, `language-powershell`, or `language-xml` across all 20 pages; 37 plain-text/pseudo-code blocks left untagged
- **Prism core + autoloader** injected via cdnjs CDN — language components fetched on demand, no bundle bloat
- **`eggspot.css`** — removed hardcoded `color: var(--text)` from `pre code` so Prism token colours render correctly

## Test plan

- [ ] Open any content page and verify C# code blocks are syntax-highlighted
- [ ] Check keyword colour (blue `#7b9eff`), string colour (green), type names (yellow)
- [ ] Verify bash/shell blocks on Quick Start and Performance pages highlight correctly
- [ ] Confirm inline `<code>` spans still use the amber colour (not affected by Prism)
- [ ] Check no console errors about missing Prism language components

🤖 Generated with [Claude Code](https://claude.com/claude-code)