### PR TITLE
docs: lower right-side TOC panel breakpoint to 1280px

### DIFF
--- a/docs/assets/css/eggspot.css
+++ b/docs/assets/css/eggspot.css
@@ -160,7 +160,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
 .toc-panel::-webkit-scrollbar { width: 3px; }
 .toc-panel::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 
-@media (min-width: 1380px) { .toc-panel { display: block; } }
+@media (min-width: 1280px) { .toc-panel { display: block; } }
 
 .toc-panel-label {
   font-size: 0.68rem; font-weight: 700;


### PR DESCRIPTION
## Summary
- Lowers the `min-width` breakpoint for the right-side \"On this page\" TOC panel from `1380px` → `1280px`
- Panel was already implemented and wired up; it just wasn't visible on standard 1280px displays
- Applies to all content pages (Advanced Features, Getting Started, API Reference, etc.) — the panel is JS-generated from `h2` headings at runtime, no per-page HTML changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)