### PR TITLE
docs: rename Tier2/Tier3 URLs to Attribute-Mapper and Class-Mapper

### DIFF
--- a/docs/API-Reference.html
+++ b/docs/API-Reference.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/Advanced-Features.html
+++ b/docs/Advanced-Features.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/Attribute-Mapper.html
+++ b/docs/Attribute-Mapper.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">
@@ -178,7 +178,7 @@ public static partial class OrderToOrderDtoExtensions
           <tr><td>Want type errors at build time, not runtime</td><td><strong>Attribute Mapper</strong></td></tr>
         </tbody>
       </table></div>
-      <nav class="page-nav"><a class="page-nav-link prev" href="Migration-Guide.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Migration Guide</span></a><a class="page-nav-link next" href="Tier3-Getting-Started.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Class Mapper</span></a></nav>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Migration-Guide.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Migration Guide</span></a><a class="page-nav-link next" href="Class-Mapper.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Class Mapper</span></a></nav>
 
     </div>
   </main>

--- a/docs/Class-Mapper.html
+++ b/docs/Class-Mapper.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">
@@ -205,7 +205,7 @@ public partial class StatusMapper
           <tr><td>Property rename/ignore</td><td>Yes — <code>[MapProperty]</code>/<code>[MapIgnore]</code></td><td>via converter method</td></tr>
         </tbody>
       </table></div>
-      <nav class="page-nav"><a class="page-nav-link prev" href="Tier2-Getting-Started.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Attribute Mapper</span></a></nav>
+      <nav class="page-nav"><a class="page-nav-link prev" href="Attribute-Mapper.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">Attribute Mapper</span></a></nav>
 
     </div>
   </main>

--- a/docs/Configuration.html
+++ b/docs/Configuration.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/Dependency-Injection.html
+++ b/docs/Dependency-Injection.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/Getting-Started.html
+++ b/docs/Getting-Started.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/Migration-Guide.html
+++ b/docs/Migration-Guide.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">
@@ -315,7 +315,7 @@ public partial class OrderMapper
           <tr><td>DI singleton</td><td>N/A (static extension)</td><td><code>MyMapper.Instance</code> + constructor injection</td></tr>
         </tbody>
       </table></div>
-      <nav class="page-nav"><a class="page-nav-link prev" href="vs-automapper.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">vs AutoMapper</span></a><a class="page-nav-link next" href="Tier2-Getting-Started.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Attribute Mapper</span></a></nav>
+      <nav class="page-nav"><a class="page-nav-link prev" href="vs-automapper.html"><span class="page-nav-label">&larr; Previous</span><span class="page-nav-title">vs AutoMapper</span></a><a class="page-nav-link next" href="Attribute-Mapper.html"><span class="page-nav-label">Next &rarr;</span><span class="page-nav-title">Attribute Mapper</span></a></nav>
 
     </div>
   </main>

--- a/docs/Performance.html
+++ b/docs/Performance.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/Profiles.html
+++ b/docs/Profiles.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/diagnostics/EGG1002.html
+++ b/docs/diagnostics/EGG1002.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/diagnostics/EGG1003.html
+++ b/docs/diagnostics/EGG1003.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">
@@ -92,7 +92,7 @@ public class Order { ... }
 // Usage:
 var dto = order.ToOrderDto();</code></pre>
 
-      <p>See <a href="../Tier2-Getting-Started.html">Tier 2 Getting Started</a> for full details.</p>
+      <p>See <a href="../Attribute-Mapper.html">Attribute Mapper</a> for full details.</p>
 
       <h2>How to suppress</h2>
 

--- a/docs/diagnostics/EGG2001.html
+++ b/docs/diagnostics/EGG2001.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/diagnostics/EGG2002.html
+++ b/docs/diagnostics/EGG2002.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/diagnostics/EGG3001.html
+++ b/docs/diagnostics/EGG3001.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/diagnostics/EGG3002.html
+++ b/docs/diagnostics/EGG3002.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/diagnostics/EGG3003.html
+++ b/docs/diagnostics/EGG3003.html
@@ -46,8 +46,8 @@
     <a class="nav-link nav-link-sub" href="../Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="../Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="../Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="../Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <section class="hero">

--- a/docs/quick-start.html
+++ b/docs/quick-start.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -11,8 +11,8 @@
   <url><loc>https://eggspot.github.io/EggMapper/API-Reference.html</loc><priority>0.8</priority></url>
   <url><loc>https://eggspot.github.io/EggMapper/vs-automapper.html</loc><priority>0.9</priority></url>
   <url><loc>https://eggspot.github.io/EggMapper/Migration-Guide.html</loc><priority>0.8</priority></url>
-  <url><loc>https://eggspot.github.io/EggMapper/Tier2-Getting-Started.html</loc><priority>0.7</priority></url>
-  <url><loc>https://eggspot.github.io/EggMapper/Tier3-Getting-Started.html</loc><priority>0.7</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Attribute-Mapper.html</loc><priority>0.7</priority></url>
+  <url><loc>https://eggspot.github.io/EggMapper/Class-Mapper.html</loc><priority>0.7</priority></url>
   <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG1002.html</loc><priority>0.5</priority></url>
   <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG1003.html</loc><priority>0.5</priority></url>
   <url><loc>https://eggspot.github.io/EggMapper/diagnostics/EGG2001.html</loc><priority>0.5</priority></url>

--- a/docs/vs-automapper.html
+++ b/docs/vs-automapper.html
@@ -49,8 +49,8 @@
     <a class="nav-link nav-link-sub" href="Migration-Guide.html">Migration Guide</a>
     <div class="nav-divider"></div>
     <div class="nav-section-label">Code Generation</div>
-    <a class="nav-link nav-link-sub" href="Tier2-Getting-Started.html">Attribute Mapper</a>
-    <a class="nav-link nav-link-sub" href="Tier3-Getting-Started.html">Class Mapper</a>
+    <a class="nav-link nav-link-sub" href="Attribute-Mapper.html">Attribute Mapper</a>
+    <a class="nav-link nav-link-sub" href="Class-Mapper.html">Class Mapper</a>
   </nav>
   <main class="main-content">
     <div class="content-wrapper">


### PR DESCRIPTION
## Summary
- Renames `Tier2-Getting-Started.html` → `Attribute-Mapper.html`
- Renames `Tier3-Getting-Started.html` → `Class-Mapper.html`
- Updates all 21 files that referenced the old URLs (nav links, prev/next, inline links, sitemap)
- Package names (`EggMapper.Generator`, `EggMapper.ClassMapper`) confirmed correct — they match the actual `PackageId` in each `.csproj`

## Why
The "Tier 2 / Tier 3" naming was an internal concept that leaked into public URLs. The pages describe distinct products with their own names, so the URLs should match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)