### PR TITLE
feat: publish EggMapper.Generator and EggMapper.ClassMapper to NuGet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,6 +151,14 @@ jobs:
             --configuration Release --no-build \
             -p:Version=${{ steps.version.outputs.VERSION }} \
             --output ./artifacts
+          dotnet pack src/EggMapper.Generator/EggMapper.Generator.csproj \
+            --configuration Release --no-build \
+            -p:Version=${{ steps.version.outputs.VERSION }} \
+            --output ./artifacts
+          dotnet pack src/EggMapper.ClassMapper/EggMapper.ClassMapper.csproj \
+            --configuration Release --no-build \
+            -p:Version=${{ steps.version.outputs.VERSION }} \
+            --output ./artifacts
 
       - name: Upload artifacts
         if: steps.tag_check.outputs.ALREADY_TAGGED == 'false'

--- a/docs/Attribute-Mapper.html
+++ b/docs/Attribute-Mapper.html
@@ -24,7 +24,7 @@
       <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
       GitHub
     </a>
-    <a class="header-link" href="https://www.nuget.org/packages/EggMapper" target="_blank" rel="noopener">NuGet</a>
+    <a class="header-link" href="https://www.nuget.org/packages/EggMapper.Generator" target="_blank" rel="noopener">NuGet</a>
   </nav>
 </header>
 <div class="sidebar-overlay" id="overlay"></div>
@@ -187,7 +187,7 @@ public static partial class OrderToOrderDtoExtensions
   <span>EggMapper &mdash; MIT licensed &copy; <a href="https://eggspot.app">Eggspot</a>. Fastest .NET runtime object mapper.</span>
   <div class="footer-links">
     <a href="https://github.com/eggspot/EggMapper" target="_blank" rel="noopener">GitHub</a>
-    <a href="https://www.nuget.org/packages/EggMapper" target="_blank" rel="noopener">NuGet</a>
+    <a href="https://www.nuget.org/packages/EggMapper.Generator" target="_blank" rel="noopener">NuGet</a>
     <a href="https://github.com/eggspot/EggMapper/issues" target="_blank" rel="noopener">Issues</a>
   </div>
 </footer>

--- a/docs/Class-Mapper.html
+++ b/docs/Class-Mapper.html
@@ -24,7 +24,7 @@
       <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
       GitHub
     </a>
-    <a class="header-link" href="https://www.nuget.org/packages/EggMapper" target="_blank" rel="noopener">NuGet</a>
+    <a class="header-link" href="https://www.nuget.org/packages/EggMapper.ClassMapper" target="_blank" rel="noopener">NuGet</a>
   </nav>
 </header>
 <div class="sidebar-overlay" id="overlay"></div>
@@ -214,7 +214,7 @@ public partial class StatusMapper
   <span>EggMapper &mdash; MIT licensed &copy; <a href="https://eggspot.app">Eggspot</a>. Fastest .NET runtime object mapper.</span>
   <div class="footer-links">
     <a href="https://github.com/eggspot/EggMapper" target="_blank" rel="noopener">GitHub</a>
-    <a href="https://www.nuget.org/packages/EggMapper" target="_blank" rel="noopener">NuGet</a>
+    <a href="https://www.nuget.org/packages/EggMapper.ClassMapper" target="_blank" rel="noopener">NuGet</a>
     <a href="https://github.com/eggspot/EggMapper/issues" target="_blank" rel="noopener">Issues</a>
   </div>
 </footer>

--- a/src/EggMapper.ClassMapper/EggMapper.ClassMapper.csproj
+++ b/src/EggMapper.ClassMapper/EggMapper.ClassMapper.csproj
@@ -2,6 +2,19 @@
   <PropertyGroup>
     <AssemblyName>EggMapper.ClassMapper</AssemblyName>
     <RootNamespace>EggMapper.ClassMapper</RootNamespace>
+    <PackageId>EggMapper.ClassMapper</PackageId>
+    <Authors>Eggspot</Authors>
+    <Company>Eggspot</Company>
+    <Product>EggMapper</Product>
+    <Description>Roslyn source generator for EggMapper. Generates compile-time, zero-reflection mapping methods from [EggMapper] partial class declarations. Supports nested types, collections, reverse mapping, and custom converters.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/eggspot/EggMapper</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/eggspot/EggMapper</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>mapper;source-generator;compile-time;roslyn;class-mapper</PackageTags>
+    <Copyright>Copyright © Eggspot</Copyright>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- Adds full NuGet metadata to `EggMapper.ClassMapper.csproj` — was missing `PackageId`, `Authors`, `Description`, `License`, `RepositoryUrl`, and `Tags`
- Extends the publish pipeline to pack and push all 3 packages on every release: `EggMapper`, `EggMapper.Generator`, `EggMapper.ClassMapper`
- Fixes header/footer NuGet links on `Attribute-Mapper.html` and `Class-Mapper.html` — were incorrectly pointing to `EggMapper` instead of their own packages

## After merge
Next push to `main` that touches `src/**` will publish all 3 packages to NuGet.org at the same version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)