### PR TITLE
fix: ForMember with Condition but no MapFrom silently drops property

### DIFF
--- a/src/EggMapper.UnitTests/ConditionalMappingTests.cs
+++ b/src/EggMapper.UnitTests/ConditionalMappingTests.cs
@@ -114,4 +114,53 @@ public class ConditionalMappingTests
         var dest = mapper.Map<FlatSource, FlatDest>(src);
         dest.Value.Should().BeApproximately(3.14, 0.001);
     }
+
+    [Fact]
+    public void Condition_without_MapFrom_still_maps_by_convention()
+    {
+        // ForMember with only Condition (no MapFrom) must still apply the convention
+        // source-member lookup — otherwise the property is silently dropped.
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<FlatSource, FlatDest>()
+               .ForMember(d => d.Name, opts => opts.Condition(s => !string.IsNullOrWhiteSpace(s.Name)));
+        }).CreateMapper();
+
+        var src = new FlatSource { Name = "updated" };
+        var dest = mapper.Map<FlatSource, FlatDest>(src);
+        dest.Name.Should().Be("updated");
+    }
+
+    [Fact]
+    public void Condition_without_MapFrom_skips_when_false()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<FlatSource, FlatDest>()
+               .ForMember(d => d.Name, opts => opts.Condition(s => !string.IsNullOrWhiteSpace(s.Name)));
+        }).CreateMapper();
+
+        var src = new FlatSource { Name = "" };
+        var dest = new FlatDest { Name = "original" };
+        var result = mapper.Map(src, dest);
+        result.Name.Should().Be("original");
+    }
+
+    [Fact]
+    public void Condition_without_MapFrom_maps_into_existing_destination()
+    {
+        // Regression: Map(source, destination) with Condition-only ForMember was silently
+        // skipping the property because SourceMemberName was null and convention fallback
+        // was blocked by processedDestProps.
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<FlatSource, FlatDest>()
+               .ForMember(d => d.Name, opts => opts.Condition(s => !string.IsNullOrWhiteSpace(s.Name)));
+        }).CreateMapper();
+
+        var src = new FlatSource { Name = "new name" };
+        var dest = new FlatDest { Name = "old name" };
+        mapper.Map(src, dest);
+        dest.Name.Should().Be("new name");
+    }
 }

--- a/src/EggMapper/Execution/ExpressionBuilder.cs
+++ b/src/EggMapper/Execution/ExpressionBuilder.cs
@@ -2012,6 +2012,12 @@ internal static class ExpressionBuilder
             return BuildDirectPropAction(srcProp, destProp, propMap, compiledMaps);
         }
 
+        // No explicit MapFrom — fall back to convention (same name) so that ForMember with only
+        // Condition/NullSubstitute/etc. still maps the property instead of silently dropping it.
+        srcDetails.ReadableByName.TryGetValue(destProp.Name, out var conventionSrcProp);
+        if (conventionSrcProp != null)
+            return BuildDirectPropAction(conventionSrcProp, destProp, propMap, compiledMaps);
+
         return null;
     }
 


### PR DESCRIPTION
## Summary

- **Bug:** `.ForMember(d => d.Name, opt => opt.Condition(...))` without an explicit `MapFrom` silently dropped the property instead of mapping it by convention.
- **Root cause:** `BuildPropertyAction` returned `null` when `SourceMemberName` was `null`, but the destination property was already added to `processedDestProps` — so the convention mapping loop also skipped it, leaving zero actions for that property.
- **Fix:** Added a same-name convention fallback in `BuildPropertyAction` before the final `return null`. When `SourceMemberName` is null, EggMapper now looks up the source property by destination property name and builds the action with the full `propMap` (Condition/PreCondition/NullSubstitute) applied — matching AutoMapper's behavior.

## Impact

Any `ForMember` call that configures only guards (`Condition`, `PreCondition`, `NullSubstitute`, or combinations) without an explicit `MapFrom` was silently a no-op. With this fix those properties are correctly mapped with the guards applied.

## Test plan

- [x] `Condition_without_MapFrom_still_maps_by_convention` — property is written when condition is true
- [x] `Condition_without_MapFrom_skips_when_false` — existing destination value preserved when condition is false
- [x] `Condition_without_MapFrom_maps_into_existing_destination` — regression case: `Map(source, destination)` path
- [x] All 358 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)